### PR TITLE
Fixed defexception/1 call

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -69,7 +69,7 @@ defmodule Decimal do
 
   @context_key :"$decimal_context"
 
-  defmodule Error do
+  defexception Error, [:message, :signal, :reason, :result] do
     @moduledoc """
     The exception that all Decimal operations may raise.
 
@@ -86,16 +86,14 @@ defmodule Decimal do
     after the operation if the result needs to be inspected.
     """
 
-    defexception [:message, :signal, :reason, :result]
-
     def exception(opts) do
-      if opts[:reason] do
-        msg = "#{opts[:signal]}: #{opts[:reason]}"
+      msg = if opts[:reason] do
+        "#{opts[:signal]}: #{opts[:reason]}"
       else
-        msg = "#{opts[:signal]}"
+        "#{opts[:signal]}"
       end
 
-      struct(__MODULE__, [message: msg] ++ opts)
+      Error[message: msg, result: opts[:result]]
     end
   end
 


### PR DESCRIPTION
In Elixir 0.13.2 compilation of this module produces the following error:

```
== Compilation error on file lib/decimal.ex ==
** (CompileError) lib/decimal.ex:89: undefined function defexception/1
    (elixir) src/elixir.erl:189: :elixir.quoted_to_erl/3
    lib/decimal.ex:72: (module)
```

That's beacuse from now on `defexception` accepts only two or three parameters, and substitutes the corresponding defmodule semantically (http://elixir-lang.org/docs/stable/Kernel.html#defexception/3). This commit makes `Decimal.Error` compliant with that.
