### PR TITLE
Implements to_integer and to_float

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -813,6 +813,21 @@ defmodule Decimal do
     IO.iodata_to_binary(str)
   end
 
+
+  @doc """
+  Returns the decimal represented as an integer. Loss of precision might occur
+  as the number is truncated to an int.
+  """
+  def to_integer(num),
+    do: trunc to_float(num)
+
+  @doc """
+  Returns the decimal represented as a float. Loss of precision might occur as
+  the decimal is converted from arbitrary precision to floating precision.
+  """
+  def to_float(%Decimal{sign: sign, coef: coef, exp: exp}),
+    do: sign * (coef * :math.pow(10, exp))
+
   @doc """
   Runs function with given context.
   """

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -478,6 +478,24 @@ defmodule DecimalTest do
     assert Decimal.to_string(~d"-inf", :raw)     == "-Infinity"
   end
 
+  test "to_integer" do
+    assert Decimal.to_integer(~d"0")        == 0
+    assert Decimal.to_integer(~d"300")      == 300
+    assert Decimal.to_integer(~d"4321.768") == 4321
+    assert Decimal.to_integer(~d"-53000")   == -53000
+    assert Decimal.to_integer(~d"0.0042")   == 0
+    assert Decimal.to_integer(~d"-0")       == 0
+  end
+
+  test "to_float" do
+    assert Decimal.to_float(~d"0")                      == 0
+    assert Decimal.to_float(~d"300")                    == 300
+    assert Decimal.to_float(~d"4321.768")               == 4321.768
+    assert Decimal.to_float(~d"-53000")                 == -53000
+    assert Float.round(Decimal.to_float(~d"0.0042"), 5) == 0.0042
+    assert Decimal.to_float(~d"-0")                     == 0.0
+  end
+
   test "precision down" do
     Decimal.with_context(%Context{precision: 2, rounding: :down}, fn ->
       assert Decimal.add(~d"0", ~d"1.02") == d(1, 10, -1)


### PR DESCRIPTION
The Decimal library allows construction of %Decimal{} using either a string, a float or an int. If you ever want to get a regular number out of the Decimal again, you need to use to_string and then parse the string. 

When handling monetary values, you want to represent the value while working with it as a Decimal, but might need to store it in a database. For example, for USD, you would do something like this:

```elixir
usd = 12.34
cents = round(usd * :math.pow(10, 2))
num = %Decimal{sign: 1, coef: cents, exp: -2)

# do stuff with num

cents = Decimal.mult(num, %Decimal{sign: 1, coef: 1, exp: 2})

# store cents in db
```

At this point, you just want to get the integer value of `cents`. This commit provides two functions: `to_integer/1` and `to_float/1`. Both of these functions can have loss of precision if used incorrectly, but should be safe when used correctly. Perhaps it is a good idea to provide an `integer?` function to test whether the Decimal can safely be converted to an integer?

Test cases are also provided.
