### PR TITLE
Implements to_integer

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -814,6 +814,12 @@ defmodule Decimal do
   end
 
   @doc """
+  Returns the decimal represented as an integer. Fails when loss of precision
+  will occur.
+  """
+  def to_integer(%Decimal{sign: sign, coef: coef, exp: 0}), do: sign * coef
+
+  @doc """
   Runs function with given context.
   """
   @spec with_context(Context.t, (() -> x)) :: x when x: var

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -827,10 +827,6 @@ defmodule Decimal do
     to_integer(%Decimal{sign: sign, coef: trunc(coef / 10), exp: exp + 1})
   end
 
-  def to_integer(%Decimal{} = num) do
-    error(:invalid_operation, "not an integer", num)
-  end
-
   @doc """
   Runs function with given context.
   """

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -819,6 +819,18 @@ defmodule Decimal do
   """
   def to_integer(%Decimal{sign: sign, coef: coef, exp: 0}), do: sign * coef
 
+  def to_integer(%Decimal{sign: sign, coef: coef, exp: exp}) when (exp > 0) do
+    to_integer(%Decimal{sign: sign, coef: coef * 10, exp: exp - 1})
+  end
+
+  def to_integer(%Decimal{sign: sign, coef: coef, exp: exp}) when (exp < 0) and (Kernel.rem(coef, 10) == 0) do
+    to_integer(%Decimal{sign: sign, coef: trunc(coef / 10), exp: exp + 1})
+  end
+
+  def to_integer(%Decimal{} = num) do
+    error(:invalid_operation, "not an integer", num)
+  end
+
   @doc """
   Runs function with given context.
   """

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -489,7 +489,7 @@ defmodule DecimalTest do
       assert Decimal.to_integer(d(1, 10, 2)) == 1000
       assert Decimal.to_integer(d(1, 1000, -2)) == 10
 
-      assert_raise Error, fn ->
+      assert_raise FunctionClauseError, fn ->
         Decimal.to_integer(d(1, 1001, -2))
       end
     end)

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -478,6 +478,17 @@ defmodule DecimalTest do
     assert Decimal.to_string(~d"-inf", :raw)     == "-Infinity"
   end
 
+  test "to_integer" do
+    Decimal.with_context(%Context{precision: 36, rounding: :floor}, fn ->
+      assert Decimal.to_integer(~d"0")        == 0
+      assert Decimal.to_integer(~d"300")      == 300
+      assert Decimal.to_integer(~d"-53000")   == -53000
+      assert Decimal.to_integer(~d"-0")       == 0
+      assert Decimal.to_integer(~d"123456789123489123456789") == 123456789123489123456789
+      assert Decimal.to_integer(Decimal.mult(~d"123456789123489123456789", ~d"1000")) == 123456789123489123456789000
+    end)
+  end
+
   test "precision down" do
     Decimal.with_context(%Context{precision: 2, rounding: :down}, fn ->
       assert Decimal.add(~d"0", ~d"1.02") == d(1, 10, -1)

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -486,6 +486,12 @@ defmodule DecimalTest do
       assert Decimal.to_integer(~d"-0")       == 0
       assert Decimal.to_integer(~d"123456789123489123456789") == 123456789123489123456789
       assert Decimal.to_integer(Decimal.mult(~d"123456789123489123456789", ~d"1000")) == 123456789123489123456789000
+      assert Decimal.to_integer(d(1, 10, 2)) == 1000
+      assert Decimal.to_integer(d(1, 1000, -2)) == 10
+
+      assert_raise Error, fn ->
+        Decimal.to_integer(d(1, 1001, -2))
+      end
     end)
   end
 


### PR DESCRIPTION
As discussed previously, this function facilitates the case where a conversion to an integer can be made without loss of precision. It does so by only implementing the case where the `exp` is `0`.

Note that this also rejects the case where loss of precision has previously occurred because of the context: if the precision of the context requires it to round down the number (and as such increase the `exp`), this function will fail. This is the conservative approach, and could by resolved by allowing any positive `exp` rather than only `0`. A negative `exp` should never be supported, since that would always result in loss of precision.