### PR TITLE
Specs and docs contrasting cmp/2 vs compare/2

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -269,7 +269,8 @@ defmodule Decimal do
   @doc """
   Compares two numbers numerically. If the first number is greater than the second
   `#Decimal<1>` is returned, if less than `Decimal<-1>` is returned. Otherwise,
-  if both numbers are equal `Decimal<0>` is returned.
+  if both numbers are equal `Decimal<0>` is returned.  If either number is a quiet
+  NaN, then that number is returned.
   """
   @spec compare(t, t) :: t
   def compare(%Decimal{coef: coef1} = num1, %Decimal{coef: coef2} = num2) do
@@ -289,7 +290,9 @@ defmodule Decimal do
   @doc """
   Compares two numbers numerically. If the first number is greater than the second
   `:gt` is returned, if less than `:lt` is returned, if both numbers are equal
-  `:eq` is returned. Neither number can be a `NaN`.
+  `:eq` is returned.
+
+  Neither number can be a `NaN`.  If you need to handle quiet NaNs, use `compare/2`.
   """
   @spec cmp(t, t) :: :lt | :eq | :gt
   def cmp(num1, num2) do

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -289,9 +289,9 @@ defmodule Decimal do
   @doc """
   Compares two numbers numerically. If the first number is greater than the second
   `:gt` is returned, if less than `:lt` is returned, if both numbers are equal
-  `:eq` is returned. Otherwise, if any number is a `NaN`, NaN is returned.
+  `:eq` is returned. Neither number can be a `NaN`.
   """
-  @spec cmp(t, t) :: :lt | :eq | :gt | :qNaN
+  @spec cmp(t, t) :: :lt | :eq | :gt
   def cmp(num1, num2) do
     case compare(num1, num2) do
       %Decimal{coef: 1, sign: -1} -> :lt


### PR DESCRIPTION
Fixes #30

# Changelog
## Enhancements
* Document `compare/2` handles quite NaNs
* Add pointer from `cmp/2` to `compare/2` for users that are looking for comparison of potential quiet NaNs.

## Bug Fixes
* Remove `:qNaN` from `cmp/2` `@spec`, as it doesn't return that value and doesn't handle NaNs at all, which is now shown in the docs.