### PR TITLE
Bugfix: Decimal.to_integer for large coefficients

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -991,7 +991,7 @@ defmodule Decimal do
 
   def to_integer(%Decimal{sign: sign, coef: coef, exp: exp})
   when is_integer(coef) and exp < 0 and Kernel.rem(coef, 10) == 0 do
-    to_integer(%Decimal{sign: sign, coef: trunc(coef / 10), exp: exp + 1})
+    to_integer(%Decimal{sign: sign, coef: Kernel.div(coef, 10), exp: exp + 1})
   end
 
   @doc """

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -512,6 +512,7 @@ defmodule DecimalTest do
       assert Decimal.to_integer(d(1, 1000, -2)) == 10
       assert Decimal.to_integer(~d"123456789123489123456789") == 123456789123489123456789
       assert Decimal.to_integer(Decimal.mult(~d"123456789123489123456789", ~d"1000")) == 123456789123489123456789000
+      assert Decimal.to_integer(d(1, 1365900000000000000000, -2)) == 13659000000000000000
 
       assert_raise FunctionClauseError, fn ->
         Decimal.to_integer(d(1, 1001, -2))


### PR DESCRIPTION
__Problem__:

Some decimals with large coefficients and negative exponents do not convert to integers.
The reason is that the `Kernel./2` is used, rather than `Kernel.div/2`, [which relies on the OS implementation of division](https://tetontech.wordpress.com/2008/05/24/handling-very-large-integers-in-erlang/), and therefore produces rounding errors.

__To reproduce__:

```elixir
iex(1)> decimal = Decimal.new(1, 1365900000000000000000, -2)
#Decimal<13659000000000000000.00>

# Before fix
iex(2)> decimal |> Decimal.to_integer()
** (FunctionClauseError) no function clause matching in Decimal.to_integer/1
    (decimal) lib/decimal.ex:818: Decimal.to_integer(#Decimal<13659000000000001638.4>)

# After fix
iex(2)> decimal |> Decimal.to_integer()
13659000000000000000
```

__Fix__:

The fix is to use `Kernel.div/2` rather than `Kernel./2` in order to force an integer division.