### PR TITLE
Added Numeric behaviour support.

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -45,7 +45,14 @@ defmodule Decimal do
   according to the specification, return a number that "underflow" 0 is returned
   instead of Etiny. This may happen when dividing a number with infinity.
   Additionally, overflow, underflow and clamped may never be signalled.
+
+  Decimal follows the arithmetic specification outlined in the `Numeric` behaviour
+  from the [Numbers](https://hex.pm/packages/numbers) package,
+  which means that it can be used with any structures, functions and libraries
+  that expect their contents/arguments/operands to follow this behaviour.
   """
+
+  @behaviour Numeric
 
   import Bitwise
   import Kernel, except: [abs: 1, div: 2, max: 2, min: 2, rem: 1, round: 1]

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule Decimal.Mixfile do
 
   defp deps do
     [{:ex_doc,  ">= 0.0.0", only: :dev},
-     {:earmark, ">= 0.0.0", only: :dev}]
+     {:earmark, ">= 0.0.0", only: :dev},
+     {:numbers, "~> 2.0", only: :dev}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
 %{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "numbers": {:hex, :numbers, "2.0.1", "ddccab36d4cd201071bac8d57e1a905634ff6711681a9019e984e4cab40a3a78", [:mix], []}}


### PR DESCRIPTION
I have recently written out a simple specification to standardize the arithmetic functions that are used in the different numberlike types that exist in Elixir right now.

This allows other functions to call e.g. `Numbers.add(x, y)` regardless of if `x` and `y` are integers, Floats, `Decimal`s, `Ratio`nals, `ComplexNum`s, etc, by dispatching the arithmetic to the module that has the same name as the struct(s) `x` and `y`.

This behaviour, `Numeric`, was very much molded after the shape that Decimal has right now, which means that Decimal can already be used with it as-is (behaviours are after all only opt-in compiler checks). To make this support more clear, however, this PR adds  `@behaviour Numeric` to the Decimal module, and a small paragraph in the documentation that states that Decimal follows the Numeric specification.

