### PR TITLE
Additional rounding tests for ~0 values

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1205,7 +1205,8 @@ defmodule Decimal do
         %Decimal{sign: sign, coef: digits_to_integer(digits), exp: exp}
 
       exp < target_exp and precision < 0 ->
-        digits = [?0|digits]
+        zeros = :lists.duplicate(target_exp - exp, ?0)
+        digits = zeros ++ digits
         {signif, remain} = :lists.split(1, digits)
         signif = if increment?(rounding, sign, signif, remain), do: digits_increment(signif), else: signif
         coef = digits_to_integer(signif)

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -739,7 +739,6 @@ defmodule DecimalTest do
   end
 
   test "issue #35" do
-    Decimal.new(1,5,-4) |> Decimal.round(0)
     assert Decimal.round(~d"0.0001", 0, :down)      == d(1, 0, 0)
     assert Decimal.round(~d"0.0001", 0, :ceiling)   == d(1, 1, 0)
     assert Decimal.round(~d"0.0001", 0, :floor)     == d(1, 0, 0)

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -747,6 +747,14 @@ defmodule DecimalTest do
     assert Decimal.round(~d"0.0001", 0, :half_even) == d(1, 0, 0)
     assert Decimal.round(~d"0.0001", 0, :half_down) == d(1, 0, 0)
     assert Decimal.round(~d"0.0001", 0, :up)        == d(1, 1, 0)
+
+    assert Decimal.round(~d"0.0005", 0, :down)      == d(1, 0, 0)
+    assert Decimal.round(~d"0.0005", 0, :ceiling)   == d(1, 1, 0)
+    assert Decimal.round(~d"0.0005", 0, :floor)     == d(1, 0, 0)
+    assert Decimal.round(~d"0.0005", 0, :half_up)   == d(1, 0, 0)
+    assert Decimal.round(~d"0.0005", 0, :half_even) == d(1, 0, 0)
+    assert Decimal.round(~d"0.0005", 0, :half_down) == d(1, 0, 0)
+    assert Decimal.round(~d"0.0005", 0, :up)        == d(1, 1, 0)
   end
 
   test "issue #29" do


### PR DESCRIPTION
Related to https://github.com/ericmj/decimal/issues/35

Rounding does not work as expected for near-zero values with first significant nonzero value >= 5, e.g.
`0.00001` is rounded to `0`, while `0.00005` is rounded to `1`.