### PR TITLE
Call Integer.to_char_list for Elixir versions < 1.3.0 and Integer.to_charlist for Elixir versions >= 1.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: elixir
 elixir:
+  - 1.0.5
+  - 1.1.1
+  - 1.2.6
   - 1.3.4
   - 1.4.5
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
-language: erlang
-otp_release:
-  - 18.0
-sudo: false
-before_install:
-  - wget http://s3.hex.pm/builds/elixir/master.zip
-  - unzip -d elixir master.zip
+language: elixir
+elixir:
+  - 1.3.4
+  - 1.4.5
 before_script:
-  - export PATH=`pwd`/elixir/bin:$PATH
   - mix local.hex --force
   - mix deps.get
 script:

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -941,7 +941,7 @@ defmodule Decimal do
   end
 
   def to_string(%Decimal{sign: sign, coef: coef, exp: exp}, :normal) do
-    list = Integer.to_char_list(coef)
+    list = integer_to_charlist(coef)
 
     list =
       if exp >= 0 do
@@ -960,7 +960,7 @@ defmodule Decimal do
   end
 
   def to_string(%Decimal{sign: sign, coef: coef, exp: exp}, :scientific) do
-    list = Integer.to_char_list(coef)
+    list = integer_to_charlist(coef)
     length = length(list)
     adjusted = exp + length - 1
 
@@ -983,7 +983,7 @@ defmodule Decimal do
           list = if length > 1, do: List.insert_at(list, 1, ?.), else: list
           list = list ++ 'E'
           list = if exp >= 0, do: list ++ '+', else: list
-          list ++ Integer.to_char_list(adjusted)
+          list ++ integer_to_charlist(adjusted)
       end
 
     list = if sign == -1, do: [?-|list], else: list
@@ -1442,6 +1442,12 @@ defmodule Decimal do
     else
       {:ok, result}
     end
+  end
+
+  if Version.compare(System.version, "1.3.0") == :lt do
+    defp integer_to_charlist(string), do: Integer.to_char_list(string)
+  else
+    defp integer_to_charlist(string), do: Integer.to_charlist(string)
   end
 end
 


### PR DESCRIPTION
Uses the same adapter strategy as hex to use either `Integer.to_char_list/1` or `Integer.to_charlist/1` depending on whether Elixir version is 1.3.0 or earlier.

This results in removing the deprecation warnings for `Integer.to_char_list/1` in Elixir 1.5.0