### PR TITLE
Add comparisons to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,25 @@ iex> D.div(D.new(31), D.new(2))
 #Decimal<15>
 ```
 
+### Comparisons
+
+Using compare operators (`<`, `=`, `>`) directly in two decimals may not return
+the correct result. Instead use comparison functions.
+
+```elixir
+iex> D.cmp(D.new(-1), D.new(0))
+:lt
+iex> D.cmp(D.new(0), D.new(-1))
+:gt
+iex> D.cmp(D.new(0), D.new(0))
+:eq
+
+iex> D.equal?(D.new(-1), D.new(0))
+false
+iex> D.equal?(D.new(0), D.new(0))
+true
+```
+
 ### Flags and trap enablers
 
 When an exceptional condition is signalled its flag is set in the context and if


### PR DESCRIPTION
Help lower the entry barrier to use this package.

As someone new to elixir behaviour like this is very confusing:

```elixir
Decimal.new(-1) > Decimal.new(0) # true
Decimal.new(-1) < Decimal.new(0) # false
```

Adding a little extra documentation in the readme to make it
easier for rookie developers to start using this package.