### PR TITLE
fix float conversion with bigger precision than 4

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -895,7 +895,7 @@ defmodule Decimal do
   end
 
   def new(float) when is_float(float) do
-    float |> :io_lib_format.fwrite_g() |> IO.iodata_to_binary() |> new()
+    float |> :io_lib_format.fwrite_g() |> fix_float_exp() |> IO.iodata_to_binary() |> new()
   end
 
   def new(binary) when is_binary(binary) do
@@ -1474,6 +1474,18 @@ defmodule Decimal do
       {:ok, result}
     end
   end
+
+  defp fix_float_exp(digits) do
+    fix_float_exp(digits, [])
+  end
+
+  defp fix_float_exp([?e | rest], [?0 | [?. | result]]) do
+    fix_float_exp(rest, [?e | result])
+  end
+  defp fix_float_exp([digit | rest], result) do
+    fix_float_exp(rest, [digit | result])
+  end
+  defp fix_float_exp([], result), do: :lists.reverse(result)
 
   if Version.compare(System.version, "1.3.0") == :lt do
     defp integer_to_charlist(string), do: Integer.to_char_list(string)

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -42,6 +42,7 @@ defmodule DecimalTest do
   test "float conversion" do
     assert Decimal.new(123.0) == d(1, 1230, -1)
     assert Decimal.new(0.1) == d(1, 1, -1)
+    assert Decimal.new(0.000015) == d(1, 15, -6)
     assert Decimal.new(-1.5) == d(-1, 15, -1)
   end
 
@@ -808,7 +809,7 @@ defmodule DecimalTest do
     assert Decimal.round(~d"0.6",        0, :half_even) == d(1, 1, 0)
     assert Decimal.round(~d"0.4",        0, :half_even) == d(1, 0, 0)
   end
-  
+
   test "issue #60" do
     assert_raise(FunctionClauseError, "no function clause matching in Decimal.round/3", fn ->
       Decimal.round(nil)

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -41,6 +41,7 @@ defmodule DecimalTest do
 
   test "float conversion" do
     assert Decimal.new(123.0) == d(1, 1230, -1)
+    assert Decimal.new(0.1) == d(1, 1, -1)
     assert Decimal.new(-1.5) == d(-1, 15, -1)
   end
 
@@ -774,6 +775,17 @@ defmodule DecimalTest do
     assert Decimal.rem(~d"1.234", ~d"1") == d(1, 234, -3)
     assert Decimal.rem(~d"1.234", ~d"1.0") == d(1, 234, -3)
     assert Decimal.rem(~d"1.234", ~d"1.00") == d(1, 234, -3)
+  end
+
+  test "issue #62" do
+    assert Decimal.new(0.0001)     == d(1, 1, -4)
+    assert Decimal.new(0.00001)    == d(1, 1, -5)
+    assert Decimal.new(0.000001)   == d(1, 1, -6)
+    assert Decimal.new(-0.0001)    == d(-1, 1, -4)
+    assert Decimal.new(-0.00001)   == d(-1, 1, -5)
+    assert Decimal.new(-0.000001)  == d(-1, 1, -6)
+    assert Decimal.new(0.00002)    == d(1, 2, -5)
+    assert Decimal.new(0.00009)    == d(1, 9, -5)
   end
 
   test "issue #57" do


### PR DESCRIPTION
A bit "hacky" way of dealing with #62 but the more clean solution (like using `:mochinum`) would require much more work which I think is unnecessary in this case