### PR TITLE
Soft deprecate passing float to new/1 in favor of from_float/1

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -215,20 +215,6 @@ defmodule Decimal do
     end
   end
 
-  if Version.compare(System.version(), "1.3.0") == :lt do
-    defmacrop warn(message) do
-      quote do
-        IO.puts(:stderr, "warning: " <> unquote(message))
-      end
-    end
-  else
-    defmacrop warn(message) do
-      quote do
-        IO.warn(unquote(message))
-      end
-    end
-  end
-
   @doc """
   Returns `true` if number is NaN, otherwise `false`.
   """
@@ -1045,7 +1031,6 @@ defmodule Decimal do
     do: %Decimal{sign: if(int < 0, do: -1, else: 1), coef: Kernel.abs(int)}
 
   def new(float) when is_float(float) do
-    warn("passing floats to new/1 is deprecated, use from_float/1 instead")
     from_float(float)
   end
 

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -215,6 +215,20 @@ defmodule Decimal do
     end
   end
 
+  if Version.compare(System.version(), "1.3.0") == :lt do
+    defmacrop warn(message) do
+      quote do
+        IO.puts(:stderr, "warning: " <> unquote(message))
+      end
+    end
+  else
+    defmacrop warn(message) do
+      quote do
+        IO.warn(unquote(message))
+      end
+    end
+  end
+
   @doc """
   Returns `true` if number is NaN, otherwise `false`.
   """
@@ -1031,6 +1045,7 @@ defmodule Decimal do
     do: %Decimal{sign: if(int < 0, do: -1, else: 1), coef: Kernel.abs(int)}
 
   def new(float) when is_float(float) do
+    warn("passing floats to new/1 is deprecated, use from_float/1 instead")
     from_float(float)
   end
 

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -40,10 +40,10 @@ defmodule DecimalTest do
   end
 
   test "float conversion" do
-    assert Decimal.new(123.0) == d(1, 1230, -1)
-    assert Decimal.new(0.1) == d(1, 1, -1)
-    assert Decimal.new(0.000015) == d(1, 15, -6)
-    assert Decimal.new(-1.5) == d(-1, 15, -1)
+    assert Decimal.from_float(123.0) == d(1, 1230, -1)
+    assert Decimal.from_float(0.1) == d(1, 1, -1)
+    assert Decimal.from_float(0.000015) == d(1, 15, -6)
+    assert Decimal.from_float(-1.5) == d(-1, 15, -1)
   end
 
   test "string conversion" do
@@ -824,14 +824,14 @@ defmodule DecimalTest do
   end
 
   test "issue #62" do
-    assert Decimal.new(0.0001) == d(1, 1, -4)
-    assert Decimal.new(0.00001) == d(1, 1, -5)
-    assert Decimal.new(0.000001) == d(1, 1, -6)
-    assert Decimal.new(-0.0001) == d(-1, 1, -4)
-    assert Decimal.new(-0.00001) == d(-1, 1, -5)
-    assert Decimal.new(-0.000001) == d(-1, 1, -6)
-    assert Decimal.new(0.00002) == d(1, 2, -5)
-    assert Decimal.new(0.00009) == d(1, 9, -5)
+    assert Decimal.from_float(0.0001) == d(1, 1, -4)
+    assert Decimal.from_float(0.00001) == d(1, 1, -5)
+    assert Decimal.from_float(0.000001) == d(1, 1, -6)
+    assert Decimal.from_float(-0.0001) == d(-1, 1, -4)
+    assert Decimal.from_float(-0.00001) == d(-1, 1, -5)
+    assert Decimal.from_float(-0.000001) == d(-1, 1, -6)
+    assert Decimal.from_float(0.00002) == d(1, 2, -5)
+    assert Decimal.from_float(0.00009) == d(1, 9, -5)
   end
 
   test "issue #57" do


### PR DESCRIPTION
Ref https://elixirforum.com/t/gringotts-a-complete-payment-library-for-elixir-and-phoenix-framework/11054/40 cc @kipcole9 

I guess I should have started discussion first but it was so easy to create a patch (and thus determine impact) so here we are :) If we would be to ever hard deprecate it, a notable call to this is in Ecto: [Ecto.Type.cast](https://github.com/elixir-ecto/ecto/blob/v2.2/lib/ecto/type.ex#L322:L324) so it would warn a lot.

As part of the PR I added a commit that adds hard deprecations: https://github.com/ericmj/decimal/commit/8a22acc003d6eaf050289c22fb956dcde711b044 (reverted for now)

