### PR TITLE
Fix incorrect float values when converting from decimal to float

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1259,6 +1259,7 @@ defmodule Decimal do
 
     sign = if sign == -1, do: 1, else: 0
     tmp = tmp - @power_of_2_to_52
+    exp = if tmp < @power_of_2_to_52, do: exp, else: exp + 1
     <<tmp::float>> = <<sign::size(1), exp + 1023::size(11), tmp::size(52)>>
     tmp
   end

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -912,4 +912,11 @@ defmodule DecimalTest do
         assert ex.result == d(1, :sNaN, 0)
     end
   end
+
+  test "issue #82" do
+    to_float = fn binary -> Decimal.new(binary) |> Decimal.to_float end
+    assert to_float.("0.8888888888888888888888") == 0.8888888888888888888888
+    assert to_float.("0.9999999999999999") == 0.9999999999999999
+    assert to_float.("0.99999999999999999") == 0.99999999999999999
+  end
 end


### PR DESCRIPTION
Addresses #82.

When determining the significand, in the case described in the issue, it can exceed 2^52. This means when masking the significand in the binary form it can output an incorrect float value. This is remedied in this commit by incrementing the exponent when the significand is detected to be >= 2^52.