### PR TITLE
Remove unused clause

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1402,10 +1402,6 @@ defmodule Decimal do
     end
   end
 
-  defp do_reduce(0, _exp) do
-    %Decimal{coef: 0, exp: 0}
-  end
-
   defp do_reduce(coef, exp) do
     if Kernel.rem(coef, 10) == 0 do
       do_reduce(Kernel.div(coef, 10), exp + 1)


### PR DESCRIPTION
The function that uses `do_reduce` already checks if the `coef` is 0:

```elixir
def reduce(%Decimal{sign: sign, coef: coef, exp: exp}) do
  if coef == 0 do
    %Decimal{sign: sign, coef: 0, exp: 0}
  else
    %{do_reduce(coef, exp) | sign: sign} |> context
  end
end
```

For this reason, the function `do_reduce` can never be called with `coef` being 0.