### PR TITLE
Support for canonical XSD representation on to_string/2

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1221,7 +1221,7 @@ defmodule Decimal do
        do: canonical_xsd(%{decimal | coef: coef * 10, exp: exp - 1})
 
   defp canonical_xsd(%Decimal{coef: coef} = decimal)
-       when Kernel.rem(coef, 100) != 0,
+       when Kernel.rem(coef, 10) != 0,
        do: decimal
 
   defp canonical_xsd(%Decimal{coef: coef, exp: exp} = decimal),

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -559,6 +559,30 @@ defmodule DecimalTest do
     assert Decimal.to_string(~d"-inf", :raw) == "-Infinity"
   end
 
+  test "to_string xsd" do
+    assert Decimal.to_string(~d"0", :xsd) == "0.0"
+    assert Decimal.to_string(~d"0.0", :xsd) == "0.0"
+    assert Decimal.to_string(~d"0.001", :xsd) == "0.001"
+    assert Decimal.to_string(~d"-0", :xsd) == "-0.0"
+    assert Decimal.to_string(~d"-1", :xsd) == "-1.0"
+    assert Decimal.to_string(~d"-0.00", :xsd) == "-0.0"
+    assert Decimal.to_string(~d"1.00", :xsd) == "1.0"
+    assert Decimal.to_string(~d"1000", :xsd) == "1000.0"
+    assert Decimal.to_string(~d"1000.000000", :xsd) == "1000.0"
+    assert Decimal.to_string(~d"12345.000", :xsd) == "12345.0"
+    assert Decimal.to_string(~d"42", :xsd) == "42.0"
+    assert Decimal.to_string(~d"42.42", :xsd) == "42.42"
+    assert Decimal.to_string(~d"0.42", :xsd) == "0.42"
+    assert Decimal.to_string(~d"0.0042", :xsd) == "0.0042"
+    assert Decimal.to_string(~d"-1.23", :xsd) == "-1.23"
+    assert Decimal.to_string(~d"-0.0123", :xsd) == "-0.0123"
+    assert Decimal.to_string(~d"1E+2", :xsd) == "100.0"
+    assert Decimal.to_string(~d"-42E+3", :xsd) == "-42000.0"
+    assert Decimal.to_string(~d"nan", :xsd) == "NaN"
+    assert Decimal.to_string(~d"-nan", :xsd) == "-NaN"
+    assert Decimal.to_string(~d"-inf", :xsd) == "-Infinity"
+  end
+
   test "to_integer" do
     Decimal.with_context(%Context{precision: 36, rounding: :floor}, fn ->
       assert Decimal.to_integer(~d"0") == 0
@@ -914,7 +938,7 @@ defmodule DecimalTest do
   end
 
   test "issue #82" do
-    to_float = fn binary -> Decimal.new(binary) |> Decimal.to_float end
+    to_float = fn binary -> Decimal.new(binary) |> Decimal.to_float() end
     assert to_float.("0.8888888888888888888888") == 0.8888888888888888888888
     assert to_float.("0.9999999999999999") == 0.9999999999999999
     assert to_float.("0.99999999999999999") == 0.99999999999999999

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -574,6 +574,7 @@ defmodule DecimalTest do
     assert Decimal.to_string(~d"42.42", :xsd) == "42.42"
     assert Decimal.to_string(~d"0.42", :xsd) == "0.42"
     assert Decimal.to_string(~d"0.0042", :xsd) == "0.0042"
+    assert Decimal.to_string(~d"010.020", :xsd) == "10.02"
     assert Decimal.to_string(~d"-1.23", :xsd) == "-1.23"
     assert Decimal.to_string(~d"-0.0123", :xsd) == "-0.0123"
     assert Decimal.to_string(~d"1E+2", :xsd) == "100.0"


### PR DESCRIPTION
<https://www.w3.org/TR/xmlschema-2/#decimal>

I've needed and implemented this for [RDF.ex](https://github.com/marcelotto/rdf-ex) and thought this might be of general interest since it's a standardized decimal representation. As it turned out, I actually need in my use case the added `canonical_xsd/1` function, so would require it to be public. If you were willing to accept this, I would add some documentation and tests for it.