### PR TITLE
Fix new @spec

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1053,7 +1053,7 @@ defmodule Decimal do
       #Decimal<3.14>
 
   """
-  @spec new(t | integer | String.t()) :: t
+  @spec new(t | integer | float | String.t()) :: t
   def new(%Decimal{} = num), do: num
 
   def new(int) when is_integer(int),


### PR DESCRIPTION
# Changelog
## Bug Fixes
* `new/1` `@spec` was missing `float` even though there is an `is_float` clause for `new`.