### PR TITLE
Mark ex_doc as only: :docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Decimal.Mixfile do
 
   defp deps() do
     [
-      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:ex_doc, ">= 0.0.0", only: :docs},
       {:earmark, ">= 0.0.0", only: :dev}
     ]
   end


### PR DESCRIPTION
Recent ExDoc versions can't build on old Elixir versions which breaks CI.