### PR TITLE
fix(decimal): Add from float for integers

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -891,7 +891,7 @@ defmodule Decimal do
   @doc """
   Check if given number is positive
   """
-  doc_since "1.5.0"
+  doc_since("1.5.0")
   @spec positive?(t) :: boolean
   def positive?(%Decimal{coef: :sNaN} = num),
     do: error(:invalid_operation, "operation on NaN", num)
@@ -904,7 +904,7 @@ defmodule Decimal do
   @doc """
   Check if given number is negative
   """
-  doc_since "1.5.0"
+  doc_since("1.5.0")
   @spec negative?(t) :: boolean
   def negative?(%Decimal{coef: :sNaN} = num),
     do: error(:invalid_operation, "operation on NaN", num)
@@ -1109,9 +1109,21 @@ defmodule Decimal do
       #Decimal<3.14>
 
   """
-  doc_since "1.5.0"
+  doc_since("1.5.0")
   @spec from_float(float) :: t
   def from_float(float) when is_float(float) do
+    float
+    |> format_float()
+  end
+
+  doc_since("1.5.0")
+  @spec from_float(float) :: t
+  def from_float(float) when is_integer(float) do
+    (float / 1)
+    |> format_float()
+  end
+
+  defp format_float(float) do
     float
     |> :io_lib_format.fwrite_g()
     |> fix_float_exp()

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -44,6 +44,10 @@ defmodule DecimalTest do
     assert Decimal.from_float(0.1) == d(1, 1, -1)
     assert Decimal.from_float(0.000015) == d(1, 15, -6)
     assert Decimal.from_float(-1.5) == d(-1, 15, -1)
+    assert Decimal.from_float(-1.0) == d(-1, 10, -1)
+    assert Decimal.from_float(-1) == d(-1, 10, -1)
+    assert Decimal.from_float(123) == d(1, 1230, -1)
+    assert Decimal.from_float(0) == d(1, 0, -1)
   end
 
   test "string conversion" do


### PR DESCRIPTION
I was using `Decimal.from_float/1` as `Decimal.new/1` in my code, but noticed its handling for integers was a bit off,  wherein Decimal.new would just accept a float or integer.

I thought it might be wise for from_float then be able to also handle integers, despite the name.