### PR TITLE
Add sqrt/1 function

### DIFF
--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -819,6 +819,21 @@ defmodule DecimalTest do
     assert roundneg.(~d"1099") == d(1, 11, 2)
   end
 
+  test "sqrt" do
+    Decimal.with_context(%Context{precision: 9, rounding: :half_even}, fn ->
+      assert Decimal.sqrt(~d"0") == d(1, 0, 0)
+      assert Decimal.sqrt(~d"-0") == d(-1, 0, 0)
+      assert Decimal.sqrt(~d"1") == d(1, 1, 0)
+      assert Decimal.sqrt(~d"1.0") == d(1, 10, -1)
+      assert Decimal.sqrt(~d"1.00") == d(1, 10, -1)
+      assert Decimal.sqrt(~d"0.01") == d(1, 1, -1)
+      assert Decimal.sqrt(~d"100") == d(1, 10, 0)
+      assert Decimal.sqrt(~d"10") == d(1, 316_227_766, -8)
+      assert Decimal.sqrt(~d"7") == d(1, 264_575_131, -8)
+      assert Decimal.sqrt(~d"0.39") == d(1, 624_499_800, -9)
+    end)
+  end
+
   test "issue #13" do
     round_down = &Decimal.round(&1, 0, :down)
     round_up = &Decimal.round(&1, 0, :up)


### PR DESCRIPTION
Official Java, Ruby and Python implementations use decimal arithmetic and intermediate decimals to converge on the square root ([Babylonian method](https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method)).

However, https://github.com/tim/erlang-decimal leverages Erlang’s arbitrary-sized integers by shifting the input as big as needed for the desired precision, then converge on the root by using integer arithmetic only.

I feel the latter method is far more idiomatic to BEAM languages, and that is the approach taken here.

This implementation complies with IEEE 754, namely:

- the square root’s preferred exponent is `floor(exp/2)`
- an operand less than zero is an invalid operation
- every square root has a positive sign, except `sqrt(-0)` shall be `-0`
- `sqrt(+∞)` is `+∞`

Fixes #50.