### PR TITLE
Add public sigils for Decimal library

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1863,6 +1863,20 @@ defmodule Decimal do
   end
 end
 
+defmodule Decimal.Sigils do
+  @moduledoc """
+  Decimal sigils to easily create decimal numbers.
+
+  ## Examples
+     iex> ~d[42.42]
+     #Decimal<42.42>
+  """
+
+  defmacro sigil_d({:<<>>, _, [string]}, _opts) do
+    Macro.escape(Decimal.new(string))
+  end
+end
+
 defimpl Inspect, for: Decimal do
   def inspect(dec, _opts) do
     "#Decimal<" <> Decimal.to_string(dec) <> ">"

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -6,17 +6,13 @@ defmodule DecimalTest do
 
   require Decimal
 
+  import Decimal.Sigils
+
   doctest Decimal
 
   defmacrop d(sign, coef, exp) do
     quote do
       %Decimal{sign: unquote(sign), coef: unquote(coef), exp: unquote(exp)}
-    end
-  end
-
-  defmacrop sigil_d(str, _opts) do
-    quote do
-      Decimal.new(unquote(str))
     end
   end
 


### PR DESCRIPTION
I find this sigil very useful to create decimal numbers. However,
I don't know what would be the proper name. `D` is used for `Date`,
`d` is good. However...

In Elixir convention, uppercase letter should not allow interpolation,
down case letters allows string interpolation. It means, some might
expect `d` to be a string interpolation version of `Date`. But,
since you have to explicit invoke `import Decimal.Sigils`, I think that's
fine.

Would be better to find a not used uppercase letter for `Decimal`.

I tried to find a discussion about the sigil usage here, but I couldn't. If the sigil feature is not wanted, I understand.