### PR TITLE
Add Decimal.from_any/1 function to handle int, float, and binary input

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1179,7 +1179,7 @@ defmodule Decimal do
 
   def new(float) when is_float(float) do
     IO.warn(
-      "passing float to Decimal.new/1 is deprecated as floats have inherent inaccuracy. Use Decimal.from_float/1 instead"
+      "passing float to Decimal.new/1 is deprecated as floats have inherent inaccuracy. Use Decimal.from_float/1 or Decimal.from_any/1 instead"
     )
 
     from_float(float)
@@ -1236,6 +1236,32 @@ defmodule Decimal do
     |> IO.iodata_to_binary()
     |> new()
   end
+
+  @doc """
+  Creates a new decimal number from an integer, string or float.
+
+  Because conversion from a floating point number is not exact, it's recommended
+  to instead use `new/1` or `from_float/1` when the argument's type is certain.
+  See `from_float/1`.
+
+  ## Examples
+
+      iex> Decimal.from_any(3)
+      #Decimal<3>
+
+      iex> Decimal.from_any(3.0)
+      #Decimal<3.0>
+
+      iex> Decimal.from_any("3")
+      #Decimal<3>
+
+      iex> Decimal.from_any("3.0")
+      #Decimal<3.0>
+
+  """
+  @spec from_any(number | binary) :: t
+  def from_any(float) when is_float(float), do: from_float(float)
+  def from_any(value), do: new(value)
 
   @doc """
   Parses a binary into a decimal.

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -115,6 +115,13 @@ defmodule DecimalTest do
     end
   end
 
+  test "from_any conversion" do
+    assert Decimal.from_any(123) == d(1, 123, 0)
+    assert Decimal.from_any(123.0) == d(1, 1230, -1)
+    assert Decimal.from_any("123") == d(1, 123, 0)
+    assert Decimal.from_any("123.0") == d(1, 1230, -1)
+  end
+
   test "abs" do
     assert Decimal.abs(~d"123") == d(1, 123, 0)
     assert Decimal.abs(~d"-123") == d(1, 123, 0)

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -115,7 +115,7 @@ defmodule DecimalTest do
     end
   end
 
-  test "from_any conversion" do
+  test "from_any" do
     assert Decimal.from_any(123) == d(1, 123, 0)
     assert Decimal.from_any(123.0) == d(1, 1230, -1)
     assert Decimal.from_any("123") == d(1, 123, 0)


### PR DESCRIPTION
We've had issues with warnings from passing a float to `Decimal.new/1` in some of the 1,000+ calls in our production Elixir application, since sometimes we want to create a Decimal without knowing the type we're passing in ahead of time. 

We created this new function to handle that scenario in our app, then realized it might be better as part of the public interface of this library. Since float conversion is not exact, its module doc encourages people to use `Decimal.new/1` or `Decimal.from_float/1` instead whenever possible.

We also noticed that Ecto implemented a `decimal_new/1` to workaround these same warnings, so if this is added to Decimal, it could be used instead of that work-around in Ecto:

https://github.com/elixir-ecto/ecto/blob/6bc632e90f0639e4643c77e599b357dac2a9acb4/lib/ecto/changeset.ex#L2047

And it would more explicitly allow for the functionality requested in this earlier PR: https://github.com/ericmj/decimal/pull/109

Thanks for your consideration!