### PR TITLE
Eliminated IO.warn from Decimal.new/1 when float.

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1178,10 +1178,6 @@ defmodule Decimal do
     do: %Decimal{sign: if(int < 0, do: -1, else: 1), coef: Kernel.abs(int)}
 
   def new(float) when is_float(float) do
-    IO.warn(
-      "passing float to Decimal.new/1 is deprecated as floats have inherent inaccuracy. Use Decimal.from_float/1 instead"
-    )
-
     from_float(float)
   end
 


### PR DESCRIPTION
1. `IO.warn` causes IEX to hang.
2. `IO.warn` creates excessive and unnecessary warnings at compile & run time. (This is a low-level library. We are all developers and get that if we convert a `float` to a `Decimal` we could lose precision.)
3. If anything, `from_float` should be a private function. Forcing folks to use `from_float` directly adds unnecessary logic to code (e.g. if a developer is parsing JSON, why force them to pre-check if its a `float`, an `integer` or a `binary`. This is already handled nicely by `Decimal.new/1`)