### PR TITLE
Update tests and docs to reflect from_any/1 accepting decimal input

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1238,7 +1238,7 @@ defmodule Decimal do
   end
 
   @doc """
-  Creates a new decimal number from an integer, string or float.
+  Creates a new decimal number from an integer, string, float, or existing decimal number.
 
   Because conversion from a floating point number is not exact, it's recommended
   to instead use `new/1` or `from_float/1` when the argument's type is certain.
@@ -1258,8 +1258,11 @@ defmodule Decimal do
       iex> Decimal.from_any("3.0")
       #Decimal<3.0>
 
+      iex> Decimal.new(3) |> Decimal.from_any()
+      #Decimal<3>
+
   """
-  @spec from_any(number | binary) :: t
+  @spec from_any(float | decimal) :: t
   def from_any(float) when is_float(float), do: from_float(float)
   def from_any(value), do: new(value)
 

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -120,6 +120,7 @@ defmodule DecimalTest do
     assert Decimal.from_any(123.0) == d(1, 1230, -1)
     assert Decimal.from_any("123") == d(1, 123, 0)
     assert Decimal.from_any("123.0") == d(1, 1230, -1)
+    assert Decimal.new(123) |> Decimal.from_any() == Decimal.new(123)
   end
 
   test "abs" do


### PR DESCRIPTION
Small update to documentation, typspec, and tests requested in the discussion here: https://github.com/ericmj/decimal/pull/116#pullrequestreview-241607628

Since `new/1` can accept a decimal input, and is called by `from_any/1`, the tests and documentation now reflect that fact. 

Also updated its typespec to use the `decimal` type to account for any of decimal / integer / string.
