### PR TITLE
Add cmp/2 helpers eq?/2, gt?/2, and lt?/2

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -460,9 +460,7 @@ defmodule Decimal do
 
   """
   @spec eq?(decimal, decimal) :: boolean
-  def eq?(num1, num2) do
-    equal?(num1, num2)
-  end
+  def eq?(num1, num2), do: equal?(num1, num2)
 
   @doc """
   Compares two numbers numerically and returns `true` if the the first argument is greater than the second,
@@ -479,9 +477,7 @@ defmodule Decimal do
 
   """
   @spec gt?(decimal, decimal) :: boolean
-  def gt?(num1, num2) do
-    cmp(num1, num2) == :gt
-  end
+  def gt?(num1, num2), do: cmp(num1, num2) == :gt
 
   @doc """
   Compares two numbers numerically and returns `true` if the the first number is less than the second number,
@@ -497,9 +493,7 @@ defmodule Decimal do
 
   """
   @spec lt?(decimal, decimal) :: boolean
-  def lt?(num1, num2) do
-    cmp(num1, num2) == :lt
-  end
+  def lt?(num1, num2), do: cmp(num1, num2) == :lt
 
   @doc """
   Divides two numbers.

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -448,6 +448,60 @@ defmodule Decimal do
   end
 
   @doc """
+  Synonymous with equal?/2 
+
+  ## Examples
+
+      iex> Decimal.eq?("1.0", 1)
+      true
+
+      iex> Decimal.eq?(1, -1)
+      false
+
+  """
+  @spec eq?(decimal, decimal) :: boolean
+  def eq?(num1, num2) do
+    equal?(num1, num2)
+  end
+
+  @doc """
+  Compares two numbers numerically and returns `true` if the the first argument is greater than the second,
+  otherwise `false`.
+
+
+  ## Examples
+
+      iex> Decimal.gt?("1.3", "1.2")
+      true
+
+      iex> Decimal.gt?("1.2", "1.3")
+      false
+
+  """
+  @spec gt?(decimal, decimal) :: boolean
+  def gt?(num1, num2) do
+    cmp(num1, num2) == :gt
+  end
+
+  @doc """
+  Compares two numbers numerically and returns `true` if the the first number is less than the second number,
+  otherwise `false`.
+
+  ## Examples
+
+      iex> Decimal.lt?("1.1", "1.2")
+      true
+
+      iex> Decimal.lt?("1.4", "1.2")
+      false
+
+  """
+  @spec lt?(decimal, decimal) :: boolean
+  def lt?(num1, num2) do
+    cmp(num1, num2) == :lt
+  end
+
+  @doc """
   Divides two numbers.
 
   ## Exceptional conditions

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -461,6 +461,7 @@ defmodule Decimal do
       false
 
   """
+  doc_since("1.8.0")
   @spec eq?(decimal, decimal) :: boolean
   def eq?(%Decimal{coef: :qNaN}, _num2), do: false
   def eq?(_num1, %Decimal{coef: :qNaN}), do: false

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -448,7 +448,9 @@ defmodule Decimal do
   end
 
   @doc """
-  Synonymous with equal?/2 
+  Compares two numbers numerically and returns `true` if they are equal,
+  otherwise `false`. If one of the operands is a quiet NaN this operation 
+  will always return `false`.
 
   ## Examples
 
@@ -460,12 +462,14 @@ defmodule Decimal do
 
   """
   @spec eq?(decimal, decimal) :: boolean
-  def eq?(num1, num2), do: equal?(num1, num2)
+  def eq?(%Decimal{coef: :qNaN}, _num2), do: false
+  def eq?(_num1, %Decimal{coef: :qNaN}), do: false
+  def eq?(num1, num2), do: cmp(num1, num2) == :eq
 
   @doc """
-  Compares two numbers numerically and returns `true` if the the first argument is greater than the second,
-  otherwise `false`.
-
+  Compares two numbers numerically and returns `true` if the the first argument 
+  is greater than the second, otherwise `false`. If one the operands is a 
+  quiet NaN this operation will always return `false`.
 
   ## Examples
 
@@ -477,11 +481,14 @@ defmodule Decimal do
 
   """
   @spec gt?(decimal, decimal) :: boolean
+  def gt?(%Decimal{coef: :qNaN}, _num2), do: false
+  def gt?(_num1, %Decimal{coef: :qNaN}), do: false
   def gt?(num1, num2), do: cmp(num1, num2) == :gt
 
   @doc """
-  Compares two numbers numerically and returns `true` if the the first number is less than the second number,
-  otherwise `false`.
+  Compares two numbers numerically and returns `true` if the the first number is 
+  less than the second number, otherwise `false`. If one of the operands is a 
+  quiet NaN this operation will always return `false`.
 
   ## Examples
 
@@ -493,6 +500,8 @@ defmodule Decimal do
 
   """
   @spec lt?(decimal, decimal) :: boolean
+  def lt?(%Decimal{coef: :qNaN}, _num2), do: false
+  def lt?(_num1, %Decimal{coef: :qNaN}), do: false
   def lt?(num1, num2), do: cmp(num1, num2) == :lt
 
   @doc """

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -481,6 +481,7 @@ defmodule Decimal do
       false
 
   """
+  doc_since("1.8.0")
   @spec gt?(decimal, decimal) :: boolean
   def gt?(%Decimal{coef: :qNaN}, _num2), do: false
   def gt?(_num1, %Decimal{coef: :qNaN}), do: false

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -501,6 +501,7 @@ defmodule Decimal do
       false
 
   """
+  doc_since("1.8.0")
   @spec lt?(decimal, decimal) :: boolean
   def lt?(%Decimal{coef: :qNaN}, _num2), do: false
   def lt?(_num1, %Decimal{coef: :qNaN}), do: false

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -265,13 +265,11 @@ defmodule DecimalTest do
     assert Decimal.gt?(~d"1", ~d"0")
     refute Decimal.gt?(~d"0", ~d"1")
     refute Decimal.gt?(~d"0", ~d"-0")
+    refute Decimal.gt?(~d"nan", ~d"1")
+    refute Decimal.gt?(~d"1", ~d"nan")
 
     assert_raise Error, fn ->
       Decimal.gt?(~d"snan", ~d"0")
-    end
-
-    assert_raise CaseClauseError, fn ->
-      Decimal.gt?(~d"nan", ~d"1")
     end
   end
 
@@ -280,13 +278,11 @@ defmodule DecimalTest do
     refute Decimal.lt?(~d"1", ~d"0")
     assert Decimal.lt?(~d"0", ~d"1")
     refute Decimal.lt?(~d"0", ~d"-0")
+    refute Decimal.lt?(~d"nan", ~d"1")
+    refute Decimal.lt?(~d"1", ~d"nan")
 
     assert_raise Error, fn ->
       Decimal.lt?(~d"snan", ~d"0")
-    end
-
-    assert_raise CaseClauseError, fn ->
-      Decimal.lt?(~d"nan", ~d"1")
     end
   end
 

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -247,6 +247,49 @@ defmodule DecimalTest do
     end
   end
 
+  test "eq?" do
+    assert Decimal.eq?(~d"420", ~d"42e1")
+    refute Decimal.eq?(~d"1", ~d"0")
+    refute Decimal.eq?(~d"0", ~d"1")
+    assert Decimal.eq?(~d"0", ~d"-0")
+    refute Decimal.eq?(~d"nan", ~d"1")
+    refute Decimal.eq?(~d"1", ~d"nan")
+
+    assert_raise Error, fn ->
+      Decimal.eq?(~d"snan", ~d"0")
+    end
+  end
+
+  test "gt?" do
+    refute Decimal.gt?(~d"420", ~d"42e1")
+    assert Decimal.gt?(~d"1", ~d"0")
+    refute Decimal.gt?(~d"0", ~d"1")
+    refute Decimal.gt?(~d"0", ~d"-0")
+
+    assert_raise Error, fn ->
+      Decimal.gt?(~d"snan", ~d"0")
+    end
+
+    assert_raise CaseClauseError, fn ->
+      Decimal.gt?(~d"nan", ~d"1")
+    end
+  end
+
+  test "lt?" do
+    refute Decimal.lt?(~d"420", ~d"42e1")
+    refute Decimal.lt?(~d"1", ~d"0")
+    assert Decimal.lt?(~d"0", ~d"1")
+    refute Decimal.lt?(~d"0", ~d"-0")
+
+    assert_raise Error, fn ->
+      Decimal.lt?(~d"snan", ~d"0")
+    end
+
+    assert_raise CaseClauseError, fn ->
+      Decimal.lt?(~d"nan", ~d"1")
+    end
+  end
+
   test "div" do
     Decimal.with_context(%Context{precision: 5, rounding: :half_up}, fn ->
       assert Decimal.div(~d"1", ~d"3") == d(1, 33333, -5)


### PR DESCRIPTION
This PR closes #119. 

I am not sure about `eq?/2` at this point... it merely wraps `equal?`, but is consistent with `lt?` and `gt?`. 

 I did not use `cmp/2` in `eq?/2` because of the NaN case, but this will be true of `lt?/2` and `gt?/2`... but this begs the question... could `cmp/2` have a clause for NaN? 