### PR TITLE
Rename from_any function to cast

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1244,6 +1244,8 @@ defmodule Decimal do
   to instead use `new/1` or `from_float/1` when the argument's type is certain.
   See `from_float/1`.
 
+  If the value cannot be cast, Decimal.Error is raised.
+
   ## Examples
 
       iex> Decimal.cast(3)

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1179,7 +1179,7 @@ defmodule Decimal do
 
   def new(float) when is_float(float) do
     IO.warn(
-      "passing float to Decimal.new/1 is deprecated as floats have inherent inaccuracy. Use Decimal.from_float/1 or Decimal.from_any/1 instead"
+      "passing float to Decimal.new/1 is deprecated as floats have inherent inaccuracy. Use Decimal.from_float/1 or Decimal.cast/1 instead"
     )
 
     from_float(float)
@@ -1246,25 +1246,25 @@ defmodule Decimal do
 
   ## Examples
 
-      iex> Decimal.from_any(3)
+      iex> Decimal.cast(3)
       #Decimal<3>
 
-      iex> Decimal.from_any(3.0)
+      iex> Decimal.cast(3.0)
       #Decimal<3.0>
 
-      iex> Decimal.from_any("3")
+      iex> Decimal.cast("3")
       #Decimal<3>
 
-      iex> Decimal.from_any("3.0")
+      iex> Decimal.cast("3.0")
       #Decimal<3.0>
 
-      iex> Decimal.new(3) |> Decimal.from_any()
+      iex> Decimal.new(3) |> Decimal.cast()
       #Decimal<3>
 
   """
-  @spec from_any(float | decimal) :: t
-  def from_any(float) when is_float(float), do: from_float(float)
-  def from_any(value), do: new(value)
+  @spec cast(float | decimal) :: t
+  def cast(float) when is_float(float), do: from_float(float)
+  def cast(value), do: new(value)
 
   @doc """
   Parses a binary into a decimal.

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -115,12 +115,12 @@ defmodule DecimalTest do
     end
   end
 
-  test "from_any" do
-    assert Decimal.from_any(123) == d(1, 123, 0)
-    assert Decimal.from_any(123.0) == d(1, 1230, -1)
-    assert Decimal.from_any("123") == d(1, 123, 0)
-    assert Decimal.from_any("123.0") == d(1, 1230, -1)
-    assert Decimal.new(123) |> Decimal.from_any() == Decimal.new(123)
+  test "cast" do
+    assert Decimal.cast(123) == d(1, 123, 0)
+    assert Decimal.cast(123.0) == d(1, 1230, -1)
+    assert Decimal.cast("123") == d(1, 123, 0)
+    assert Decimal.cast("123.0") == d(1, 1230, -1)
+    assert Decimal.new(123) |> Decimal.cast() == Decimal.new(123)
   end
 
   test "abs" do

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -121,6 +121,18 @@ defmodule DecimalTest do
     assert Decimal.cast("123") == d(1, 123, 0)
     assert Decimal.cast("123.0") == d(1, 1230, -1)
     assert Decimal.new(123) |> Decimal.cast() == Decimal.new(123)
+
+    assert_raise Error, fn ->
+      Decimal.cast("one two three")
+    end
+
+    assert_raise Error, fn ->
+      Decimal.cast("e0")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Decimal.cast(:one_two_three)
+    end
   end
 
   test "abs" do


### PR DESCRIPTION
Per conversation here: https://github.com/ericmj/decimal/pull/116#issuecomment-500169337

The new from_any function can't _really_ accept any input type, so renaming it `cast` might help avoid confusion. 