### PR TITLE
Set :signal on error

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1934,7 +1934,7 @@ defmodule Decimal do
     result = if match?(%Decimal{coef: :NaN}, result), do: %{result | coef: nan}, else: result
 
     if error_signal do
-      error = [signals: error_signal, reason: reason, result: result]
+      error = [signal: error_signal, reason: reason, result: result]
       {:error, error}
     else
       {:ok, result}

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -341,8 +341,12 @@ defmodule DecimalTest do
       Decimal.div(~d"-2", ~d"-snan")
     end
 
-    assert_raise Error, fn ->
+    assert_raise Error, "invalid_operation: 0 / 0", fn ->
       Decimal.div(~d"0", ~d"-0")
+    end
+
+    assert_raise Error, "division_by_zero", fn ->
+      Decimal.div(~d"1", ~d"0")
     end
   end
 


### PR DESCRIPTION
Before:

    iex> Decimal.div(1, 0)
    ** (Decimal.Error)
        (decimal) lib/decimal.ex:563: Decimal.div/2

    iex> Decimal.add("sNaN", 1)
    ** (Decimal.Error) : operation on NaN
        (decimal) lib/decimal.ex:298: Decimal.add/2

After:

    iex> Decimal.div(1, 0)
    ** (Decimal.Error) division_by_zero
        (decimal) lib/decimal.ex:563: Decimal.div/2

    iex(1)> Decimal.add("sNaN", 1)
    ** (Decimal.Error) invalid_operation: operation on NaN
        (decimal) lib/decimal.ex:298: Decimal.add/2