### PR TITLE
Deprecate Decimal.compare/2 in favour of Decimal.cmp/2

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -397,7 +397,7 @@ defmodule Decimal do
   `:gt` is returned, if less than `:lt` is returned, if both numbers are equal
   `:eq` is returned.
 
-  Neither number can be a NaN. If you need to handle quiet NaNs, use `compare/2`.
+  Neither number can be a NaN.
 
   ## Examples
 

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -359,21 +359,8 @@ defmodule Decimal do
     sub(decimal(num1), decimal(num2))
   end
 
-  @doc """
-  Compares two numbers numerically. If the first number is greater than the second
-  `#Decimal<1>` is returned, if less than `#Decimal<-1>` is returned. Otherwise,
-  if both numbers are equal `#Decimal<0>` is returned. If either number is a quiet
-  NaN, then that number is returned.
-
-  ## Examples
-
-      iex> Decimal.compare("1.0", 1)
-      #Decimal<0>
-
-      iex> Decimal.compare("Inf", -1)
-      #Decimal<1>
-
-  """
+  @doc false
+  @deprecated "Use Decimal.cmp/2 instead"
   @spec compare(decimal, decimal) :: t
   def compare(%Decimal{coef: :qNaN} = num1, _num2), do: num1
 

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -211,38 +211,23 @@ defmodule DecimalTest do
     end
   end
 
-  test "compare/2" do
-    assert Decimal.compare(~d"420", ~d"42e1") == d(1, 0, 0)
-    assert Decimal.compare(~d"1", ~d"0") == d(1, 1, 0)
-    assert Decimal.compare(~d"0", ~d"1") == d(-1, 1, 0)
-    assert Decimal.compare(~d"0", ~d"-0") == d(1, 0, 0)
-    assert Decimal.compare(~d"nan", ~d"1") == d(1, :qNaN, 0)
-    assert Decimal.compare(~d"1", ~d"nan") == d(1, :qNaN, 0)
-
-    assert Decimal.compare(~d"-inf", ~d"inf") == d(-1, 1, 0)
-    assert Decimal.compare(~d"inf", ~d"-inf") == d(1, 1, 0)
-    assert Decimal.compare(~d"inf", ~d"0") == d(1, 1, 0)
-    assert Decimal.compare(~d"-inf", ~d"0") == d(-1, 1, 0)
-    assert Decimal.compare(~d"0", ~d"inf") == d(-1, 1, 0)
-    assert Decimal.compare(~d"0", ~d"-inf") == d(1, 1, 0)
-    assert Decimal.compare(~d"nan", ~d"inf") == d(1, :qNaN, 0)
-    assert Decimal.compare(~d"nan", ~d"-inf") == d(1, :qNaN, 0)
-
-    assert Decimal.compare("Inf", "Inf") == d(1, 0, 0)
-
-    assert_raise Error, fn ->
-      Decimal.compare(~d"snan", ~d"0")
-    end
-  end
-
   test "cmp/2" do
     assert Decimal.cmp(~d"420", ~d"42e1") == :eq
     assert Decimal.cmp(~d"1", ~d"0") == :gt
     assert Decimal.cmp(~d"0", ~d"1") == :lt
     assert Decimal.cmp(~d"0", ~d"-0") == :eq
 
+    assert Decimal.cmp(~d"-inf", ~d"inf") == :lt
+    assert Decimal.cmp(~d"inf", ~d"-inf") == :gt
+    assert Decimal.cmp(~d"inf", ~d"0") == :gt
+    assert Decimal.cmp(~d"-inf", ~d"0") == :lt
+    assert Decimal.cmp(~d"0", ~d"inf") == :lt
+    assert Decimal.cmp(~d"0", ~d"-inf") == :gt
+
+    assert Decimal.cmp("Inf", "Inf") == :eq
+
     assert_raise Error, fn ->
-      Decimal.compare(~d"snan", ~d"0")
+      Decimal.cmp(~d"snan", ~d"0")
     end
 
     assert_raise CaseClauseError, fn ->


### PR DESCRIPTION
This is in preparation for Decimal v2.0 where `Decimal.compare/2` will return `:lt | :eq | :gt`.