### PR TITLE
Add support for lte? and gte?

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -387,6 +387,29 @@ defmodule Decimal do
   def gt?(num1, num2), do: compare(num1, num2) == :gt
 
   @doc """
+  Compares two numbers numerically and returns `true` if the the first argument
+  is greater than or equal to the second, otherwise `false`. If one the operands is a
+  quiet NaN this operation will always return `false`.
+
+  ## Examples
+      
+      iex> Decimal.gte?("1.0", "1.0")
+      true
+      
+      iex> Decimal.gte?("1.3", "1.2")
+      true
+
+      iex> Decimal.gte?("1.2", "1.3")
+      false
+
+  """
+  doc_since("1.9.0")
+  @spec gte?(decimal, decimal) :: boolean
+  def gte?(%Decimal{coef: :NaN}, _num2), do: false
+  def gte?(_num1, %Decimal{coef: :NaN}), do: false
+  def gte?(num1, num2), do: compare(num1, num2) == :gt or compare(num1, num2) == :eq
+
+  @doc """
   Compares two numbers numerically and returns `true` if the the first number is
   less than the second number, otherwise `false`. If one of the operands is a
   quiet NaN this operation will always return `false`.
@@ -405,6 +428,29 @@ defmodule Decimal do
   def lt?(%Decimal{coef: :NaN}, _num2), do: false
   def lt?(_num1, %Decimal{coef: :NaN}), do: false
   def lt?(num1, num2), do: compare(num1, num2) == :lt
+
+  @doc """
+  Compares two numbers numerically and returns `true` if the the first number is
+  less or equal to the second number, otherwise `false`. If one of the operands is a
+  quiet NaN this operation will always return `false`.
+
+  ## Examples
+      
+      iex> Decimal.lte?("1.0", "1.0")
+      true
+      
+      iex> Decimal.lte?("1.1", "1.2")
+      true
+
+      iex> Decimal.lte?("1.4", "1.2")
+      false
+
+  """
+  doc_since("1.9.0")
+  @spec lte?(decimal, decimal) :: boolean
+  def lte?(%Decimal{coef: :NaN}, _num2), do: false
+  def lte?(_num1, %Decimal{coef: :NaN}), do: false
+  def lte?(num1, num2), do: compare(num1, num2) == :lt or compare(num1, num2) == :eq
 
   @doc """
   Divides two numbers.

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -279,9 +279,9 @@ defmodule DecimalTest do
   test "gte?/2" do
     assert Decimal.gte?(~d"420", ~d"42e1")
     assert Decimal.gte?(~d"0", ~d"0")
+    assert Decimal.gte?(~d"0", ~d"-0")
     assert Decimal.gte?(~d"1", ~d"0")
     refute Decimal.gte?(~d"0", ~d"1")
-    refute Decimal.gte?(~d"0", ~d"-0")
     refute Decimal.gte?(~d"nan", ~d"1")
     refute Decimal.gte?(~d"1", ~d"nan")
   end
@@ -297,10 +297,10 @@ defmodule DecimalTest do
   
   test "lte?/2" do
     assert Decimal.lte?(~d"420", ~d"42e1")
-    refute Decimal.lte?(~d"1", ~d"0")
     assert Decimal.lte?(~d"0", ~d"0")
     assert Decimal.lte?(~d"0", ~d"1")
-    refute Decimal.lte?(~d"0", ~d"-0")
+    assert Decimal.lte?(~d"0", ~d"-0")
+    refute Decimal.lte?(~d"1", ~d"0")
     refute Decimal.lte?(~d"nan", ~d"1")
     refute Decimal.lte?(~d"1", ~d"nan")
   end

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -275,6 +275,16 @@ defmodule DecimalTest do
     refute Decimal.gt?(~d"nan", ~d"1")
     refute Decimal.gt?(~d"1", ~d"nan")
   end
+  
+  test "gte?/2" do
+    refute Decimal.gte?(~d"420", ~d"42e1")
+    assert Decimal.gte?(~d"0", ~d"0")
+    assert Decimal.gte?(~d"1", ~d"0")
+    refute Decimal.gte?(~d"0", ~d"1")
+    refute Decimal.gte?(~d"0", ~d"-0")
+    refute Decimal.gte?(~d"nan", ~d"1")
+    refute Decimal.gte?(~d"1", ~d"nan")
+  end
 
   test "lt?/2" do
     refute Decimal.lt?(~d"420", ~d"42e1")
@@ -283,6 +293,16 @@ defmodule DecimalTest do
     refute Decimal.lt?(~d"0", ~d"-0")
     refute Decimal.lt?(~d"nan", ~d"1")
     refute Decimal.lt?(~d"1", ~d"nan")
+  end
+  
+  test "lte?/2" do
+    refute Decimal.lte?(~d"420", ~d"42e1")
+    refute Decimal.lte?(~d"1", ~d"0")
+    assert Decimal.lte?(~d"0", ~d"0")
+    assert Decimal.lte?(~d"0", ~d"1")
+    refute Decimal.lte?(~d"0", ~d"-0")
+    refute Decimal.lte?(~d"nan", ~d"1")
+    refute Decimal.lte?(~d"1", ~d"nan")
   end
 
   test "div/2" do

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -277,7 +277,7 @@ defmodule DecimalTest do
   end
   
   test "gte?/2" do
-    refute Decimal.gte?(~d"420", ~d"42e1")
+    assert Decimal.gte?(~d"420", ~d"42e1")
     assert Decimal.gte?(~d"0", ~d"0")
     assert Decimal.gte?(~d"1", ~d"0")
     refute Decimal.gte?(~d"0", ~d"1")
@@ -296,7 +296,7 @@ defmodule DecimalTest do
   end
   
   test "lte?/2" do
-    refute Decimal.lte?(~d"420", ~d"42e1")
+    assert Decimal.lte?(~d"420", ~d"42e1")
     refute Decimal.lte?(~d"1", ~d"0")
     assert Decimal.lte?(~d"0", ~d"0")
     assert Decimal.lte?(~d"0", ~d"1")


### PR DESCRIPTION
Hi, 

This PR should simplify the comparison of two numbers when they are either less than or equal to or when they are greater than or equal to: 

```elixir 
Decimal.lt?("0", "0") or Decimal.eq?("0", "0")  # => Decimal.lte?("0", "0")
# or
Decimal.gt?("0", "0") or Decimal.eq?("0", "0") # => Decimal.gte?("0", "0")
```

If there are any additional changes to be made, please let me know.

Thank you.