### PR TITLE
fix small bug in base10?() check

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1487,7 +1487,7 @@ defmodule Decimal do
 
   defp pow10(num) when num > 104, do: pow10(104) * pow10(num - 104)
 
-  defp base10?(num) when num > unquote(pow10_max) do
+  defp base10?(num) when num >= unquote(pow10_max) do
     if Kernel.rem(num, unquote(pow10_max)) == 0 do
       base10?(Kernel.div(num, unquote(pow10_max)))
     else


### PR DESCRIPTION
without `>=` it will result in `false` for num == pow10_max 
this would run into wrong signal under special circumstances:

```
iex(1)> Decimal.Context.set(%Decimal.Context{Decimal.Context.get() | rounding: :floor, precision: 111})
:ok

iex(2)> Decimal.Context.get()     
%Decimal.Context{
  flags: [],
  precision: 111,
  rounding: :floor,
  traps: [:invalid_operation, :division_by_zero]
}

iex(3)> Decimal.div(10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,17)
#Decimal<588235294117647058823529411764705882352941176470588235294117647058823529411764705882352941176470588235294.117647>

iex(4)> Decimal.Context.get()
%Decimal.Context{
  flags: [:rounded, :inexact],
  precision: 111,
  rounding: :floor,
  traps: [:invalid_operation, :division_by_zero]
}
```

it should be:
```
iex(4)> Decimal.Context.get()
%Decimal.Context{
  flags: [:rounded],
  precision: 111,
  rounding: :floor,
  traps: [:invalid_operation, :division_by_zero]
}
```
and it will be after this fix! ;-)

Please check it 
