### PR TITLE
Fix broken link to IEEE 854-1987

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -23,7 +23,7 @@ defmodule Decimal do
   ## Specifications
 
     * [IBM's General Decimal Arithmetic Specification](http://speleotrove.com/decimal/decarith.html)
-    * [IEEE standard 854-1987](http://754r.ucbtest.org/standards/854.pdf)
+    * [IEEE standard 854-1987](http://web.archive.org/web/20150908012941/http://754r.ucbtest.org/standards/854.pdf)
 
   This library follows the above specifications for reference of arithmetic
   operation implementations, but the public APIs may differ to provide a


### PR DESCRIPTION
I noticed the link to IEEE standard 854-1987 was broken, so I replaced it with the last working version from web.archive.org.

However, I'm not sure this is the best change because:

1. IEEE 854-1987 has been superseded by 754-2019 (here's an [interesting article](https://www.computer.org/csdl/magazine/co/2019/12/08909942/1f8KFWxbTCU) linked from the same site at the original broken link).
2. The standard is copyrighted. Maybe it was taken down on purpose. The IEEE's [official page](https://standards.ieee.org/standard/754-2019.html) charges $100 to download the standard.