### PR TITLE
Fix negative coef

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -229,6 +229,16 @@ defmodule Decimal do
 
   def add(%Decimal{}, %Decimal{coef: :inf} = num2), do: num2
 
+  def add(%Decimal{coef: coef1}, %Decimal{})
+      when coef1 < 0 do
+    error(:invalid_operation, "first coefficient (#{coef1}) must be > 0", %Decimal{coef: :NaN})
+  end
+
+  def add(%Decimal{}, %Decimal{coef: coef2})
+      when coef2 < 0 do
+    error(:invalid_operation, "second coefficient (#{coef2}) must be > 0", %Decimal{coef: :NaN})
+  end
+
   def add(%Decimal{} = num1, %Decimal{} = num2) do
     %Decimal{sign: sign1, coef: coef1, exp: exp1} = num1
     %Decimal{sign: sign2, coef: coef2, exp: exp2} = num2
@@ -308,6 +318,16 @@ defmodule Decimal do
 
   def compare(_num1, %Decimal{coef: :NaN} = num2),
     do: error(:invalid_operation, "operation on NaN", num2)
+
+  def compare(%Decimal{coef: coef1}, %Decimal{})
+      when coef1 < 0 do
+    error(:invalid_operation, "first coefficient (#{coef1}) must be > 0", %Decimal{coef: :NaN})
+  end
+
+  def compare(%Decimal{}, %Decimal{coef: coef2})
+      when coef2 < 0 do
+    error(:invalid_operation, "second coefficient (#{coef2}) must be > 0", %Decimal{coef: :NaN})
+  end
 
   def compare(%Decimal{} = num1, %Decimal{} = num2) do
     case sub(num1, num2) do
@@ -447,6 +467,16 @@ defmodule Decimal do
   def div(%Decimal{coef: 0}, %Decimal{coef: 0}),
     do: error(:invalid_operation, "0 / 0", %Decimal{coef: :NaN})
 
+  def div(%Decimal{coef: coef1}, %Decimal{})
+      when coef1 < 0 do
+    error(:invalid_operation, "dividend coefficient (#{coef1}) must be > 0", %Decimal{coef: :NaN})
+  end
+
+  def div(%Decimal{}, %Decimal{coef: coef2})
+      when coef2 < 0 do
+    error(:invalid_operation, "divisor coefficient (#{coef2}) must be > 0", %Decimal{coef: :NaN})
+  end
+
   def div(%Decimal{sign: sign1}, %Decimal{sign: sign2, coef: 0}) do
     sign = if sign1 == sign2, do: 1, else: -1
     error(:division_by_zero, nil, %Decimal{sign: sign, coef: :inf})
@@ -518,6 +548,16 @@ defmodule Decimal do
     error(:division_by_zero, nil, %Decimal{sign: div_sign, coef: :inf})
   end
 
+  def div_int(%Decimal{coef: coef1}, %Decimal{})
+      when coef1 < 0 do
+    error(:invalid_operation, "dividend coefficient (#{coef1}) must be > 0", %Decimal{coef: :NaN})
+  end
+
+  def div_int(%Decimal{}, %Decimal{coef: coef2})
+      when coef2 < 0 do
+    error(:invalid_operation, "divisor coefficient (#{coef2}) must be > 0", %Decimal{coef: :NaN})
+  end
+
   def div_int(%Decimal{} = num1, %Decimal{} = num2) do
     %Decimal{sign: sign1, coef: coef1, exp: exp1} = num1
     %Decimal{sign: sign2, coef: coef2, exp: exp2} = num2
@@ -582,6 +622,16 @@ defmodule Decimal do
 
   def rem(%Decimal{sign: sign1}, %Decimal{coef: 0}),
     do: error(:division_by_zero, nil, %Decimal{sign: sign1, coef: 0})
+
+  def rem(%Decimal{coef: coef1}, %Decimal{})
+      when coef1 < 0 do
+    error(:invalid_operation, "dividend coefficient (#{coef1}) must be > 0", %Decimal{coef: :NaN})
+  end
+
+  def rem(%Decimal{}, %Decimal{coef: coef2})
+      when coef2 < 0 do
+    error(:invalid_operation, "divisor coefficient (#{coef2}) must be > 0", %Decimal{coef: :NaN})
+  end
 
   def rem(%Decimal{} = num1, %Decimal{} = num2) do
     %Decimal{sign: sign1, coef: coef1, exp: exp1} = num1
@@ -663,6 +713,24 @@ defmodule Decimal do
     div_error = error(:division_by_zero, nil, %Decimal{sign: div_sign, coef: :inf})
     rem_error = error(:division_by_zero, nil, %Decimal{sign: sign1, coef: 0})
     {div_error, rem_error}
+  end
+
+  def div_rem(%Decimal{coef: coef1}, %Decimal{})
+      when coef1 < 0 do
+    error =
+      error(:invalid_operation, "dividend coefficient (#{coef1}) must be > 0", %Decimal{
+        coef: :NaN
+      })
+
+    {error, error}
+  end
+
+  def div_rem(%Decimal{}, %Decimal{coef: coef2})
+      when coef2 < 0 do
+    error =
+      error(:invalid_operation, "divisor coefficient (#{coef2}) must be > 0", %Decimal{coef: :NaN})
+
+    {error, error}
   end
 
   def div_rem(%Decimal{} = num1, %Decimal{} = num2) do
@@ -863,6 +931,16 @@ defmodule Decimal do
   def mult(%Decimal{coef: :inf}, %Decimal{coef: 0}),
     do: error(:invalid_operation, "0 * ±Infinity", %Decimal{coef: :NaN})
 
+  def mult(%Decimal{coef: coef1}, %Decimal{})
+      when coef1 < 0 do
+    error(:invalid_operation, "first coefficient (#{coef1}) must be > 0", %Decimal{coef: :NaN})
+  end
+
+  def mult(%Decimal{}, %Decimal{coef: coef2})
+      when coef2 < 0 do
+    error(:invalid_operation, "second coefficient (#{coef2}) must be > 0", %Decimal{coef: :NaN})
+  end
+
   def mult(%Decimal{sign: sign1, coef: :inf, exp: exp1}, %Decimal{sign: sign2, exp: exp2}) do
     sign = if sign1 == sign2, do: 1, else: -1
     # exponent?
@@ -908,12 +986,17 @@ defmodule Decimal do
     %{num | exp: 0}
   end
 
+  def normalize(%Decimal{sign: sign, coef: coef, exp: exp})
+      when coef < 0 do
+    %{do_normalize(-coef, exp) | sign: -sign} |> context
+  end
+
+  def normalize(%Decimal{sign: sign, coef: 0, exp: _exp}) do
+    %Decimal{sign: sign, coef: 0, exp: 0}
+  end
+
   def normalize(%Decimal{sign: sign, coef: coef, exp: exp}) do
-    if coef == 0 do
-      %Decimal{sign: sign, coef: 0, exp: 0}
-    else
-      %{do_normalize(coef, exp) | sign: sign} |> context
-    end
+    %{do_normalize(coef, exp) | sign: sign} |> context
   end
 
   @doc """
@@ -938,6 +1021,11 @@ defmodule Decimal do
   def round(%Decimal{coef: :NaN} = num, _, _), do: num
 
   def round(%Decimal{coef: :inf} = num, _, _), do: num
+
+  def round(%Decimal{coef: coef}, _, _)
+      when coef < 0 do
+    error(:invalid_operation, "round coefficient (#{coef}) must be > 0", %Decimal{coef: :NaN})
+  end
 
   def round(%Decimal{} = num, n, mode) do
     %Decimal{sign: sign, coef: coef, exp: exp} = normalize(num)
@@ -967,6 +1055,11 @@ defmodule Decimal do
 
   def sqrt(%Decimal{coef: 0, exp: exp} = num),
     do: %{num | exp: exp >>> 1}
+
+  def sqrt(%Decimal{coef: coef})
+      when coef < 0 do
+    error(:invalid_operation, "sqrt coefficient (#{coef}) must be > 0", %Decimal{coef: :NaN})
+  end
 
   def sqrt(%Decimal{sign: -1} = num),
     do: error(:invalid_operation, "less than zero", num)
@@ -1080,7 +1173,11 @@ defmodule Decimal do
       #Decimal<3.14>
   """
   @spec new(decimal) :: t
-  def new(%Decimal{} = num), do: num
+  def new(%Decimal{sign: sign, coef: coef, exp: exp} = num)
+      when sign in [1, -1] and ((is_integer(coef) and coef >= 0) or coef in [:NaN, :inf]) and
+             is_integer(exp) do
+    num
+  end
 
   def new(int) when is_integer(int),
     do: %Decimal{sign: if(int < 0, do: -1, else: 1), coef: Kernel.abs(int)}
@@ -1090,6 +1187,10 @@ defmodule Decimal do
       {decimal, ""} -> decimal
       _ -> raise Error, reason: "number parsing syntax: #{inspect(binary)}"
     end
+  end
+
+  def new(num) do
+    raise Error, reason: "wrong decimal number: (#{inspect(num)})"
   end
 
   @doc """
@@ -1159,6 +1260,12 @@ defmodule Decimal do
   """
   @spec cast(term) :: {:ok, t} | :error
   def cast(integer) when is_integer(integer), do: {:ok, Decimal.new(integer)}
+
+  def cast(%Decimal{coef: coef})
+      when coef < 0 do
+    :error
+  end
+
   def cast(%Decimal{} = decimal), do: {:ok, decimal}
   def cast(float) when is_float(float), do: {:ok, from_float(float)}
 
@@ -1228,6 +1335,11 @@ defmodule Decimal do
 
   def to_string(%Decimal{sign: sign, coef: :inf}, _type) do
     if sign == 1, do: "Infinity", else: "-Infinity"
+  end
+
+  def to_string(%Decimal{coef: coef}, _type)
+      when coef < 0 do
+    error(:invalid_operation, "coefficient (#{coef}) must be > 0", %Decimal{coef: :NaN})
   end
 
   def to_string(%Decimal{sign: sign, coef: coef, exp: exp}, :normal) do
@@ -1316,6 +1428,12 @@ defmodule Decimal do
   Fails when loss of precision will occur.
   """
   @spec to_integer(t) :: integer
+
+  def to_integer(%Decimal{coef: coef})
+      when coef < 0 do
+    error(:invalid_operation, "coefficient (#{coef}) must be > 0", %Decimal{coef: :NaN})
+  end
+
   def to_integer(%Decimal{sign: sign, coef: coef, exp: 0})
       when is_integer(coef),
       do: sign * coef
@@ -1335,6 +1453,11 @@ defmodule Decimal do
   the decimal cannot be converted to a float.
   """
   @spec to_float(t) :: float
+  def to_float(%Decimal{coef: coef})
+      when coef < 0 do
+    error(:invalid_operation, "coefficient (#{coef}) must be > 0", %Decimal{coef: :NaN})
+  end
+
   def to_float(%Decimal{sign: sign, coef: coef, exp: exp}) when is_integer(coef) do
     # Convert back to float without loss
     # http://www.exploringbinary.com/correct-decimal-to-floating-point-using-big-integers/

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -110,7 +110,7 @@ defmodule DecimalTest do
     assert Decimal.new(d(-1, 3, 2)) == d(-1, 3, 2)
     assert Decimal.new(123) == d(1, 123, 0)
 
-    assert_raise FunctionClauseError, fn ->
+    assert_raise Decimal.Error, fn ->
       Decimal.new(:atom)
     end
   end
@@ -834,5 +834,162 @@ defmodule DecimalTest do
     assert to_float.("0.8888888888888888888888") == 0.8888888888888888888888
     assert to_float.("0.9999999999999999") == 0.9999999999999999
     assert to_float.("0.99999999999999999") == 0.99999999999999999
+  end
+
+  test "issue negative coef" do
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(%Decimal{coef: -1})
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(%Decimal{sign: -1, coef: -1})
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.to_integer(d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.to_float(d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.to_string(d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.sqrt(d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.sqrt(%Decimal{sign: -1, coef: -1})
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.round(d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.round(d(-1, -1, -1), 1)
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.round(d(-1, -1, -1), 1, :half_up)
+    end
+
+    # mult
+    assert_raise Decimal.Error, fn ->
+      Decimal.mult(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.mult(~d"1", d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.mult(~d"1", d(1, -1, -1))
+    end
+
+    # div_rem
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_rem(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_rem(~d"1", d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_rem(~d"1", d(1, -1, -1))
+    end
+
+    # rem
+    assert_raise Decimal.Error, fn ->
+      Decimal.rem(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.rem(~d"1", d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.rem(~d"1", d(1, -1, -1))
+    end
+
+    # div_int
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_int(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_int(~d"1", d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_int(~d"1", d(1, -1, -1))
+    end
+
+    # div
+    assert_raise Decimal.Error, fn ->
+      Decimal.div(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div(~d"1", d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div(~d"1", d(1, -1, -1))
+    end
+
+    # compare
+    assert_raise Decimal.Error, fn ->
+      Decimal.compare(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.compare(~d"1", d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.compare(~d"1", d(1, -1, -1))
+    end
+
+    # sub
+    assert_raise Decimal.Error, fn ->
+      Decimal.sub(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.sub(~d"1", d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.sub(~d"1", d(1, -1, -1))
+    end
+
+    # add
+    assert_raise Decimal.Error, fn ->
+      Decimal.add(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.add(~d"1", d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.add(~d"1", d(1, -1, -1))
+    end
+
+    assert inspect(d(-1, -1, -1)) =~ "Decimal.Error"
+
+    assert Decimal.normalize(%Decimal{sign: -1, coef: -1, exp: -1}) == d(1, 1, -1)
+    assert Decimal.normalize(%Decimal{sign: -1, coef: -1}) == d(1, 1, 0)
+    assert Decimal.normalize(%Decimal{coef: -1}) == d(-1, 1, 0)
+    assert Decimal.normalize(d(1, -1, 0)) == d(-1, 1, 0)
   end
 end


### PR DESCRIPTION
Hi,

I found a bug or structural problem in Decimal what could have some big impact under special circumstances. Here an example from the Money lib where Decimal is used as main backbone:

```elixir
iex(15)> m = Money.new(:USD, Decimal.new(%Decimal{sign: -1, coef: -12000000000}))
#Money<:USD, --12000000000>
iex(16)> Money.mult(m, 3)
{:ok, #Money<:USD, --36000000000>} 
iex(17)> Money.mult!(m, 3 )|> Money.to_string 
{:ok, "$--*,000,000,000.00"}
```

Of course it's a special edge case ... normally the best practice is:

```elixir
iex(18)> m = Money.new(:USD, "-12000000000") 
#Money<:USD, -12000000000>
```
but you never know ... maybe someone using it ...it's possible! it's valid Code ! NO compiler warning! NO runtime error!

And the worst case, if you are using any division with this kind of Decimal number like this:

```elixir
iex(19)> m = Money.new(:USD, Decimal.new(%Decimal{sign: -1, coef: -12000000000}))
#Money<:USD, --12000000000>
iex(20)> Money.mult!(m, 3) |> Money.to_decimal |> Decimal.to_float
```
-> you end up in an infinite loop!!! 

The reason for this is clear: the %Decimal{} struct - with no validation for input -> so you can input a negative coefficient.

The type spec and docu are perfect - but do not prevent any misuse: 
Type spec :   @type coefficient :: non_neg_integer | :NaN | :inf
Documentation: The coefficient of the power of `10`. Non-negative because the sign is stored separately in `sign`.

So my suggestion for a solution you can find in this pull request: mostly checks for this special edge case.

And this time I included the corresponding tests. ;-) 

Kind regards and I hope it helps anybody to use Decimal in a safer way!
Ralph