### PR TITLE
Fix coef and sign

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -229,21 +229,6 @@ defmodule Decimal do
 
   def add(%Decimal{}, %Decimal{coef: :inf} = num2), do: num2
 
-  def add(%Decimal{coef: coef1}, %Decimal{coef: coef2})
-      when coef1 < 0 or coef2 < 0 do
-    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
-  end
-
-  def add(%Decimal{sign: sign1}, %Decimal{})
-      when sign1 != 1 and sign1 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
-
-  def add(%Decimal{}, %Decimal{sign: sign2})
-      when sign2 != 1 and sign2 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
-
   def add(%Decimal{} = num1, %Decimal{} = num2) do
     %Decimal{sign: sign1, coef: coef1, exp: exp1} = num1
     %Decimal{sign: sign2, coef: coef2, exp: exp2} = num2
@@ -323,21 +308,6 @@ defmodule Decimal do
 
   def compare(_num1, %Decimal{coef: :NaN} = num2),
     do: error(:invalid_operation, "operation on NaN", num2)
-
-  def compare(%Decimal{coef: coef1}, %Decimal{coef: coef2})
-      when coef1 < 0 or coef2 < 0 do
-    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
-  end
-
-  def compare(%Decimal{sign: sign1}, %Decimal{})
-      when sign1 != 1 and sign1 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
-
-  def compare(%Decimal{}, %Decimal{sign: sign2})
-      when sign2 != 1 and sign2 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
 
   def compare(%Decimal{} = num1, %Decimal{} = num2) do
     case sub(num1, num2) do
@@ -477,21 +447,6 @@ defmodule Decimal do
   def div(%Decimal{coef: 0}, %Decimal{coef: 0}),
     do: error(:invalid_operation, "0 / 0", %Decimal{coef: :NaN})
 
-  def div(%Decimal{coef: coef1}, %Decimal{coef: coef2})
-      when coef1 < 0 or coef2 < 0 do
-    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
-  end
-
-  def div(%Decimal{sign: sign1}, %Decimal{})
-      when sign1 != 1 and sign1 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
-
-  def div(%Decimal{}, %Decimal{sign: sign2})
-      when sign2 != 1 and sign2 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
-
   def div(%Decimal{sign: sign1}, %Decimal{sign: sign2, coef: 0}) do
     sign = if sign1 == sign2, do: 1, else: -1
     error(:division_by_zero, nil, %Decimal{sign: sign, coef: :inf})
@@ -563,21 +518,6 @@ defmodule Decimal do
     error(:division_by_zero, nil, %Decimal{sign: div_sign, coef: :inf})
   end
 
-  def div_int(%Decimal{coef: coef1}, %Decimal{coef: coef2})
-      when coef1 < 0 or coef2 < 0 do
-    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
-  end
-
-  def div_int(%Decimal{sign: sign1}, %Decimal{})
-      when sign1 != 1 and sign1 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
-
-  def div_int(%Decimal{}, %Decimal{sign: sign2})
-      when sign2 != 1 and sign2 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
-
   def div_int(%Decimal{} = num1, %Decimal{} = num2) do
     %Decimal{sign: sign1, coef: coef1, exp: exp1} = num1
     %Decimal{sign: sign2, coef: coef2, exp: exp2} = num2
@@ -642,21 +582,6 @@ defmodule Decimal do
 
   def rem(%Decimal{sign: sign1}, %Decimal{coef: 0}),
     do: error(:division_by_zero, nil, %Decimal{sign: sign1, coef: 0})
-
-  def rem(%Decimal{coef: coef1}, %Decimal{coef: coef2})
-      when coef1 < 0 or coef2 < 0 do
-    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
-  end
-
-  def rem(%Decimal{sign: sign1}, %Decimal{})
-      when sign1 != 1 and sign1 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
-
-  def rem(%Decimal{}, %Decimal{sign: sign2})
-      when sign2 != 1 and sign2 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
 
   def rem(%Decimal{} = num1, %Decimal{} = num2) do
     %Decimal{sign: sign1, coef: coef1, exp: exp1} = num1
@@ -738,24 +663,6 @@ defmodule Decimal do
     div_error = error(:division_by_zero, nil, %Decimal{sign: div_sign, coef: :inf})
     rem_error = error(:division_by_zero, nil, %Decimal{sign: sign1, coef: 0})
     {div_error, rem_error}
-  end
-
-  def div_rem(%Decimal{coef: coef1}, %Decimal{coef: coef2})
-      when coef1 < 0 or coef2 < 0 do
-    error = error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
-    {error, error}
-  end
-
-  def div_rem(%Decimal{sign: sign1}, %Decimal{})
-      when sign1 != 1 and sign1 != -1 do
-    error = error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-    {error, error}
-  end
-
-  def div_rem(%Decimal{}, %Decimal{sign: sign2})
-      when sign2 != 1 and sign2 != -1 do
-    error = error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-    {error, error}
   end
 
   def div_rem(%Decimal{} = num1, %Decimal{} = num2) do
@@ -956,21 +863,6 @@ defmodule Decimal do
   def mult(%Decimal{coef: :inf}, %Decimal{coef: 0}),
     do: error(:invalid_operation, "0 * ±Infinity", %Decimal{coef: :NaN})
 
-  def mult(%Decimal{coef: coef1}, %Decimal{coef: coef2})
-      when coef1 < 0 or coef2 < 0 do
-    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
-  end
-
-  def mult(%Decimal{sign: sign1}, %Decimal{})
-      when sign1 != 1 and sign1 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
-
-  def mult(%Decimal{}, %Decimal{sign: sign2})
-      when sign2 != 1 and sign2 != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
-
   def mult(%Decimal{sign: sign1, coef: :inf, exp: exp1}, %Decimal{sign: sign2, exp: exp2}) do
     sign = if sign1 == sign2, do: 1, else: -1
     # exponent?
@@ -1016,22 +908,12 @@ defmodule Decimal do
     %{num | exp: 0}
   end
 
-  def normalize(%Decimal{coef: coef})
-      when coef < 0 do
-    error(:invalid_operation, "wrong coefficient", %Decimal{coef: :NaN})
-  end
-
-  def normalize(%Decimal{sign: sign})
-      when sign != 1 and sign != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
-
-  def normalize(%Decimal{sign: sign, coef: 0, exp: _exp}) do
-    %Decimal{sign: sign, coef: 0, exp: 0}
-  end
-
   def normalize(%Decimal{sign: sign, coef: coef, exp: exp}) do
-    %{do_normalize(coef, exp) | sign: sign} |> context
+    if coef == 0 do
+      %Decimal{sign: sign, coef: 0, exp: 0}
+    else
+      %{do_normalize(coef, exp) | sign: sign} |> context
+    end
   end
 
   @doc """
@@ -1056,16 +938,6 @@ defmodule Decimal do
   def round(%Decimal{coef: :NaN} = num, _, _), do: num
 
   def round(%Decimal{coef: :inf} = num, _, _), do: num
-
-  def round(%Decimal{coef: coef}, _, _)
-      when coef < 0 do
-    error(:invalid_operation, "wrong coefficient", %Decimal{coef: :NaN})
-  end
-
-  def round(%Decimal{sign: sign}, _, _)
-      when sign != 1 and sign != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
 
   def round(%Decimal{} = num, n, mode) do
     %Decimal{sign: sign, coef: coef, exp: exp} = normalize(num)
@@ -1095,16 +967,6 @@ defmodule Decimal do
 
   def sqrt(%Decimal{coef: 0, exp: exp} = num),
     do: %{num | exp: exp >>> 1}
-
-  def sqrt(%Decimal{coef: coef})
-      when coef < 0 do
-    error(:invalid_operation, "wrong coefficient", %Decimal{coef: :NaN})
-  end
-
-  def sqrt(%Decimal{sign: sign})
-      when sign != 1 and sign != -1 do
-    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
-  end
 
   def sqrt(%Decimal{sign: -1} = num),
     do: error(:invalid_operation, "less than zero", num)
@@ -1235,7 +1097,7 @@ defmodule Decimal do
   end
 
   def new(num) do
-    raise Error, reason: "wrong decimal number: (#{inspect(num)})"
+    raise Error, reason: "wrong decimal number: #{inspect(num)}"
   end
 
   @doc """
@@ -1306,8 +1168,18 @@ defmodule Decimal do
   @spec cast(term) :: {:ok, t} | :error
   def cast(integer) when is_integer(integer), do: {:ok, Decimal.new(integer)}
 
+  def cast(%Decimal{sign: sign})
+      when not is_integer(sign) do
+    :error
+  end
+
   def cast(%Decimal{coef: coef})
-      when coef < 0 do
+      when not is_integer(coef) do
+    :error
+  end
+
+  def cast(%Decimal{exp: exp})
+      when not is_integer(exp) do
     :error
   end
 
@@ -1316,8 +1188,8 @@ defmodule Decimal do
     :error
   end
 
-  def cast(%Decimal{exp: exp})
-      when not is_integer(exp) do
+  def cast(%Decimal{coef: coef})
+      when coef < 0 do
     :error
   end
 

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -229,6 +229,11 @@ defmodule Decimal do
 
   def add(%Decimal{}, %Decimal{coef: :inf} = num2), do: num2
 
+  def add(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
+      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
+    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  end
+
   def add(%Decimal{} = num1, %Decimal{} = num2) do
     %Decimal{sign: sign1, coef: coef1, exp: exp1} = num1
     %Decimal{sign: sign2, coef: coef2, exp: exp2} = num2
@@ -308,6 +313,11 @@ defmodule Decimal do
 
   def compare(_num1, %Decimal{coef: :NaN} = num2),
     do: error(:invalid_operation, "operation on NaN", num2)
+
+  def compare(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
+      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
+    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  end
 
   def compare(%Decimal{} = num1, %Decimal{} = num2) do
     case sub(num1, num2) do
@@ -447,6 +457,11 @@ defmodule Decimal do
   def div(%Decimal{coef: 0}, %Decimal{coef: 0}),
     do: error(:invalid_operation, "0 / 0", %Decimal{coef: :NaN})
 
+  def div(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
+      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
+    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  end
+
   def div(%Decimal{sign: sign1}, %Decimal{sign: sign2, coef: 0}) do
     sign = if sign1 == sign2, do: 1, else: -1
     error(:division_by_zero, nil, %Decimal{sign: sign, coef: :inf})
@@ -518,6 +533,11 @@ defmodule Decimal do
     error(:division_by_zero, nil, %Decimal{sign: div_sign, coef: :inf})
   end
 
+  def div_int(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
+      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
+    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  end
+
   def div_int(%Decimal{} = num1, %Decimal{} = num2) do
     %Decimal{sign: sign1, coef: coef1, exp: exp1} = num1
     %Decimal{sign: sign2, coef: coef2, exp: exp2} = num2
@@ -582,6 +602,11 @@ defmodule Decimal do
 
   def rem(%Decimal{sign: sign1}, %Decimal{coef: 0}),
     do: error(:division_by_zero, nil, %Decimal{sign: sign1, coef: 0})
+
+  def rem(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
+      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
+    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  end
 
   def rem(%Decimal{} = num1, %Decimal{} = num2) do
     %Decimal{sign: sign1, coef: coef1, exp: exp1} = num1
@@ -663,6 +688,12 @@ defmodule Decimal do
     div_error = error(:division_by_zero, nil, %Decimal{sign: div_sign, coef: :inf})
     rem_error = error(:division_by_zero, nil, %Decimal{sign: sign1, coef: 0})
     {div_error, rem_error}
+  end
+
+  def div_rem(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
+      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
+    error = error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+    {error, error}
   end
 
   def div_rem(%Decimal{} = num1, %Decimal{} = num2) do
@@ -863,6 +894,11 @@ defmodule Decimal do
   def mult(%Decimal{coef: :inf}, %Decimal{coef: 0}),
     do: error(:invalid_operation, "0 * ±Infinity", %Decimal{coef: :NaN})
 
+  def mult(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
+      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
+    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  end
+
   def mult(%Decimal{sign: sign1, coef: :inf, exp: exp1}, %Decimal{sign: sign2, exp: exp2}) do
     sign = if sign1 == sign2, do: 1, else: -1
     # exponent?
@@ -908,12 +944,19 @@ defmodule Decimal do
     %{num | exp: 0}
   end
 
+  def normalize(%Decimal{sign: sign, coef: coef})
+      when coef < 0 or sign not in [1, -1] do
+    error(:invalid_operation, "wrong coefficient (#{coef}) or sign (#{sign}) ", %Decimal{
+      coef: :NaN
+    })
+  end
+
+  def normalize(%Decimal{sign: sign, coef: 0, exp: _exp}) do
+    %Decimal{sign: sign, coef: 0, exp: 0}
+  end
+
   def normalize(%Decimal{sign: sign, coef: coef, exp: exp}) do
-    if coef == 0 do
-      %Decimal{sign: sign, coef: 0, exp: 0}
-    else
-      %{do_normalize(coef, exp) | sign: sign} |> context
-    end
+    %{do_normalize(coef, exp) | sign: sign} |> context
   end
 
   @doc """
@@ -938,6 +981,13 @@ defmodule Decimal do
   def round(%Decimal{coef: :NaN} = num, _, _), do: num
 
   def round(%Decimal{coef: :inf} = num, _, _), do: num
+
+  def round(%Decimal{sign: sign, coef: coef}, _, _)
+      when coef < 0 or sign not in [1, -1] do
+    error(:invalid_operation, "wrong coefficient (#{coef}) or sign (#{sign}) ", %Decimal{
+      coef: :NaN
+    })
+  end
 
   def round(%Decimal{} = num, n, mode) do
     %Decimal{sign: sign, coef: coef, exp: exp} = normalize(num)
@@ -967,6 +1017,13 @@ defmodule Decimal do
 
   def sqrt(%Decimal{coef: 0, exp: exp} = num),
     do: %{num | exp: exp >>> 1}
+
+  def sqrt(%Decimal{sign: sign, coef: coef})
+      when coef < 0 or sign not in [1, -1] do
+    error(:invalid_operation, "wrong coefficient (#{coef}) or sign (#{sign}) ", %Decimal{
+      coef: :NaN
+    })
+  end
 
   def sqrt(%Decimal{sign: -1} = num),
     do: error(:invalid_operation, "less than zero", num)
@@ -1080,7 +1137,11 @@ defmodule Decimal do
       #Decimal<3.14>
   """
   @spec new(decimal) :: t
-  def new(%Decimal{} = num), do: num
+  def new(%Decimal{sign: sign, coef: coef, exp: exp} = num)
+      when sign in [1, -1] and ((is_integer(coef) and coef >= 0) or coef in [:NaN, :inf]) and
+             is_integer(exp) do
+    num
+  end
 
   def new(int) when is_integer(int),
     do: %Decimal{sign: if(int < 0, do: -1, else: 1), coef: Kernel.abs(int)}
@@ -1090,6 +1151,10 @@ defmodule Decimal do
       {decimal, ""} -> decimal
       _ -> raise Error, reason: "number parsing syntax: #{inspect(binary)}"
     end
+  end
+
+  def new(num) do
+    raise Error, reason: "wrong decimal number: (#{inspect(num)})"
   end
 
   @doc """
@@ -1159,6 +1224,12 @@ defmodule Decimal do
   """
   @spec cast(term) :: {:ok, t} | :error
   def cast(integer) when is_integer(integer), do: {:ok, Decimal.new(integer)}
+
+  def cast(%Decimal{sign: sign, coef: coef, exp: exp})
+      when coef < 0 or sign not in [1, -1] or not is_integer(exp) do
+    :error
+  end
+
   def cast(%Decimal{} = decimal), do: {:ok, decimal}
   def cast(float) when is_float(float), do: {:ok, from_float(float)}
 
@@ -1228,6 +1299,13 @@ defmodule Decimal do
 
   def to_string(%Decimal{sign: sign, coef: :inf}, _type) do
     if sign == 1, do: "Infinity", else: "-Infinity"
+  end
+
+  def to_string(%Decimal{sign: sign, coef: coef}, _type)
+      when coef < 0 or sign not in [1, -1] do
+    error(:invalid_operation, "coefficient (#{coef}) or sign (#{sign}) are wrong", %Decimal{
+      coef: :NaN
+    })
   end
 
   def to_string(%Decimal{sign: sign, coef: coef, exp: exp}, :normal) do
@@ -1316,6 +1394,14 @@ defmodule Decimal do
   Fails when loss of precision will occur.
   """
   @spec to_integer(t) :: integer
+
+  def to_integer(%Decimal{sign: sign, coef: coef})
+      when coef < 0 or sign not in [1, -1] do
+    error(:invalid_operation, "wrong coefficient (#{coef}) or sign (#{sign}) ", %Decimal{
+      coef: :NaN
+    })
+  end
+
   def to_integer(%Decimal{sign: sign, coef: coef, exp: 0})
       when is_integer(coef),
       do: sign * coef
@@ -1335,6 +1421,13 @@ defmodule Decimal do
   the decimal cannot be converted to a float.
   """
   @spec to_float(t) :: float
+  def to_float(%Decimal{sign: sign, coef: coef})
+      when coef < 0 or sign not in [1, -1] do
+    error(:invalid_operation, "wrong coefficient (#{coef}) or sign (#{sign}) ", %Decimal{
+      coef: :NaN
+    })
+  end
+
   def to_float(%Decimal{sign: sign, coef: coef, exp: exp}) when is_integer(coef) do
     # Convert back to float without loss
     # http://www.exploringbinary.com/correct-decimal-to-floating-point-using-big-integers/

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -229,9 +229,19 @@ defmodule Decimal do
 
   def add(%Decimal{}, %Decimal{coef: :inf} = num2), do: num2
 
-  def add(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
-      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
-    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  def add(%Decimal{coef: coef1}, %Decimal{coef: coef2})
+      when coef1 < 0 or coef2 < 0 do
+    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
+  end
+
+  def add(%Decimal{sign: sign1}, %Decimal{})
+      when sign1 != 1 and sign1 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
+  end
+
+  def add(%Decimal{}, %Decimal{sign: sign2})
+      when sign2 != 1 and sign2 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def add(%Decimal{} = num1, %Decimal{} = num2) do
@@ -314,9 +324,19 @@ defmodule Decimal do
   def compare(_num1, %Decimal{coef: :NaN} = num2),
     do: error(:invalid_operation, "operation on NaN", num2)
 
-  def compare(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
-      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
-    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  def compare(%Decimal{coef: coef1}, %Decimal{coef: coef2})
+      when coef1 < 0 or coef2 < 0 do
+    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
+  end
+
+  def compare(%Decimal{sign: sign1}, %Decimal{})
+      when sign1 != 1 and sign1 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
+  end
+
+  def compare(%Decimal{}, %Decimal{sign: sign2})
+      when sign2 != 1 and sign2 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def compare(%Decimal{} = num1, %Decimal{} = num2) do
@@ -457,9 +477,19 @@ defmodule Decimal do
   def div(%Decimal{coef: 0}, %Decimal{coef: 0}),
     do: error(:invalid_operation, "0 / 0", %Decimal{coef: :NaN})
 
-  def div(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
-      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
-    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  def div(%Decimal{coef: coef1}, %Decimal{coef: coef2})
+      when coef1 < 0 or coef2 < 0 do
+    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
+  end
+
+  def div(%Decimal{sign: sign1}, %Decimal{})
+      when sign1 != 1 and sign1 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
+  end
+
+  def div(%Decimal{}, %Decimal{sign: sign2})
+      when sign2 != 1 and sign2 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def div(%Decimal{sign: sign1}, %Decimal{sign: sign2, coef: 0}) do
@@ -533,9 +563,19 @@ defmodule Decimal do
     error(:division_by_zero, nil, %Decimal{sign: div_sign, coef: :inf})
   end
 
-  def div_int(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
-      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
-    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  def div_int(%Decimal{coef: coef1}, %Decimal{coef: coef2})
+      when coef1 < 0 or coef2 < 0 do
+    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
+  end
+
+  def div_int(%Decimal{sign: sign1}, %Decimal{})
+      when sign1 != 1 and sign1 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
+  end
+
+  def div_int(%Decimal{}, %Decimal{sign: sign2})
+      when sign2 != 1 and sign2 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def div_int(%Decimal{} = num1, %Decimal{} = num2) do
@@ -603,9 +643,19 @@ defmodule Decimal do
   def rem(%Decimal{sign: sign1}, %Decimal{coef: 0}),
     do: error(:division_by_zero, nil, %Decimal{sign: sign1, coef: 0})
 
-  def rem(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
-      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
-    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  def rem(%Decimal{coef: coef1}, %Decimal{coef: coef2})
+      when coef1 < 0 or coef2 < 0 do
+    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
+  end
+
+  def rem(%Decimal{sign: sign1}, %Decimal{})
+      when sign1 != 1 and sign1 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
+  end
+
+  def rem(%Decimal{}, %Decimal{sign: sign2})
+      when sign2 != 1 and sign2 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def rem(%Decimal{} = num1, %Decimal{} = num2) do
@@ -690,9 +740,21 @@ defmodule Decimal do
     {div_error, rem_error}
   end
 
-  def div_rem(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
-      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
-    error = error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  def div_rem(%Decimal{coef: coef1}, %Decimal{coef: coef2})
+      when coef1 < 0 or coef2 < 0 do
+    error = error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
+    {error, error}
+  end
+
+  def div_rem(%Decimal{sign: sign1}, %Decimal{})
+      when sign1 != 1 and sign1 != -1 do
+    error = error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
+    {error, error}
+  end
+
+  def div_rem(%Decimal{}, %Decimal{sign: sign2})
+      when sign2 != 1 and sign2 != -1 do
+    error = error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
     {error, error}
   end
 
@@ -894,9 +956,19 @@ defmodule Decimal do
   def mult(%Decimal{coef: :inf}, %Decimal{coef: 0}),
     do: error(:invalid_operation, "0 * ±Infinity", %Decimal{coef: :NaN})
 
-  def mult(%Decimal{sign: sign1, coef: coef1}, %Decimal{sign: sign2, coef: coef2})
-      when coef1 < 0 or coef2 < 0 or sign1 not in [1, -1] or sign2 not in [1, -1] do
-    error(:invalid_operation, "wrong sign or coef", %Decimal{coef: :NaN})
+  def mult(%Decimal{coef: coef1}, %Decimal{coef: coef2})
+      when coef1 < 0 or coef2 < 0 do
+    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
+  end
+
+  def mult(%Decimal{sign: sign1}, %Decimal{})
+      when sign1 != 1 and sign1 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
+  end
+
+  def mult(%Decimal{}, %Decimal{sign: sign2})
+      when sign2 != 1 and sign2 != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def mult(%Decimal{sign: sign1, coef: :inf, exp: exp1}, %Decimal{sign: sign2, exp: exp2}) do
@@ -944,11 +1016,14 @@ defmodule Decimal do
     %{num | exp: 0}
   end
 
-  def normalize(%Decimal{sign: sign, coef: coef})
-      when coef < 0 or sign not in [1, -1] do
-    error(:invalid_operation, "wrong coefficient (#{coef}) or sign (#{sign}) ", %Decimal{
-      coef: :NaN
-    })
+  def normalize(%Decimal{coef: coef})
+      when coef < 0 do
+    error(:invalid_operation, "wrong coefficient", %Decimal{coef: :NaN})
+  end
+
+  def normalize(%Decimal{sign: sign})
+      when sign != 1 and sign != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def normalize(%Decimal{sign: sign, coef: 0, exp: _exp}) do
@@ -982,11 +1057,14 @@ defmodule Decimal do
 
   def round(%Decimal{coef: :inf} = num, _, _), do: num
 
-  def round(%Decimal{sign: sign, coef: coef}, _, _)
-      when coef < 0 or sign not in [1, -1] do
-    error(:invalid_operation, "wrong coefficient (#{coef}) or sign (#{sign}) ", %Decimal{
-      coef: :NaN
-    })
+  def round(%Decimal{coef: coef}, _, _)
+      when coef < 0 do
+    error(:invalid_operation, "wrong coefficient", %Decimal{coef: :NaN})
+  end
+
+  def round(%Decimal{sign: sign}, _, _)
+      when sign != 1 and sign != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def round(%Decimal{} = num, n, mode) do
@@ -1018,11 +1096,14 @@ defmodule Decimal do
   def sqrt(%Decimal{coef: 0, exp: exp} = num),
     do: %{num | exp: exp >>> 1}
 
-  def sqrt(%Decimal{sign: sign, coef: coef})
-      when coef < 0 or sign not in [1, -1] do
-    error(:invalid_operation, "wrong coefficient (#{coef}) or sign (#{sign}) ", %Decimal{
-      coef: :NaN
-    })
+  def sqrt(%Decimal{coef: coef})
+      when coef < 0 do
+    error(:invalid_operation, "wrong coefficient", %Decimal{coef: :NaN})
+  end
+
+  def sqrt(%Decimal{sign: sign})
+      when sign != 1 and sign != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def sqrt(%Decimal{sign: -1} = num),
@@ -1225,8 +1306,18 @@ defmodule Decimal do
   @spec cast(term) :: {:ok, t} | :error
   def cast(integer) when is_integer(integer), do: {:ok, Decimal.new(integer)}
 
-  def cast(%Decimal{sign: sign, coef: coef, exp: exp})
-      when coef < 0 or sign not in [1, -1] or not is_integer(exp) do
+  def cast(%Decimal{coef: coef})
+      when coef < 0 do
+    :error
+  end
+
+  def cast(%Decimal{sign: sign})
+      when sign != 1 and sign != -1 do
+    :error
+  end
+
+  def cast(%Decimal{exp: exp})
+      when not is_integer(exp) do
     :error
   end
 
@@ -1301,11 +1392,14 @@ defmodule Decimal do
     if sign == 1, do: "Infinity", else: "-Infinity"
   end
 
-  def to_string(%Decimal{sign: sign, coef: coef}, _type)
-      when coef < 0 or sign not in [1, -1] do
-    error(:invalid_operation, "coefficient (#{coef}) or sign (#{sign}) are wrong", %Decimal{
-      coef: :NaN
-    })
+  def to_string(%Decimal{coef: coef}, _type)
+      when coef < 0 do
+    error(:invalid_operation, "wrong coefficient", %Decimal{coef: :NaN})
+  end
+
+  def to_string(%Decimal{sign: sign}, _type)
+      when sign != 1 and sign != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def to_string(%Decimal{sign: sign, coef: coef, exp: exp}, :normal) do
@@ -1394,12 +1488,14 @@ defmodule Decimal do
   Fails when loss of precision will occur.
   """
   @spec to_integer(t) :: integer
+  def to_integer(%Decimal{coef: coef})
+      when coef < 0 do
+    error(:invalid_operation, "wrong coefficient", %Decimal{coef: :NaN})
+  end
 
-  def to_integer(%Decimal{sign: sign, coef: coef})
-      when coef < 0 or sign not in [1, -1] do
-    error(:invalid_operation, "wrong coefficient (#{coef}) or sign (#{sign}) ", %Decimal{
-      coef: :NaN
-    })
+  def to_integer(%Decimal{sign: sign})
+      when sign != 1 and sign != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def to_integer(%Decimal{sign: sign, coef: coef, exp: 0})
@@ -1421,11 +1517,14 @@ defmodule Decimal do
   the decimal cannot be converted to a float.
   """
   @spec to_float(t) :: float
-  def to_float(%Decimal{sign: sign, coef: coef})
-      when coef < 0 or sign not in [1, -1] do
-    error(:invalid_operation, "wrong coefficient (#{coef}) or sign (#{sign}) ", %Decimal{
-      coef: :NaN
-    })
+  def to_float(%Decimal{coef: coef})
+      when coef < 0 do
+    error(:invalid_operation, "wrong coefficient", %Decimal{coef: :NaN})
+  end
+
+  def to_float(%Decimal{sign: sign})
+      when sign != 1 and sign != -1 do
+    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
   end
 
   def to_float(%Decimal{sign: sign, coef: coef, exp: exp}) when is_integer(coef) do

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -181,6 +181,7 @@ defmodule DecimalTest do
     assert Decimal.add(~d"-0", ~d"0") == d(1, 0, 0)
     assert Decimal.add(~d"-0", ~d"-0") == d(-1, 0, 0)
     assert Decimal.add(~d"2", ~d"-2") == d(1, 0, 0)
+    assert Decimal.add(~d"NaN", ~d"1") == d(1, :NaN, 0)
     assert Decimal.add(~d"5", ~d"nan") == d(1, :NaN, 0)
     assert Decimal.add(~d"inf", ~d"inf") == d(1, :inf, 0)
     assert Decimal.add(~d"-inf", ~d"-inf") == d(-1, :inf, 0)
@@ -308,6 +309,7 @@ defmodule DecimalTest do
     assert Decimal.div(~d"-0", ~d"3") == d(-1, 0, 0)
     assert Decimal.div(~d"0", ~d"-3") == d(-1, 0, 0)
     assert Decimal.div(~d"nan", ~d"2") == d(1, :NaN, 0)
+    assert Decimal.div(~d"1", ~d"NaN") == d(1, :NaN, 0)
 
     assert Decimal.div(~d"-inf", ~d"-2") == d(1, :inf, 0)
     assert Decimal.div(~d"5", ~d"-inf") == d(-1, 0, 0)
@@ -340,6 +342,7 @@ defmodule DecimalTest do
     assert Decimal.div_int(~d"-0", ~d"3") == d(-1, 0, 0)
     assert Decimal.div_int(~d"0", ~d"-3") == d(-1, 0, 0)
     assert Decimal.div_int(~d"nan", ~d"2") == d(1, :NaN, 0)
+    assert Decimal.div_int(~d"1", ~d"NaN") == d(1, :NaN, 0)
 
     assert Decimal.div_int(~d"-inf", ~d"-2") == d(1, :inf, 0)
     assert Decimal.div_int(~d"5", ~d"-inf") == d(-1, 0, 0)
@@ -350,6 +353,10 @@ defmodule DecimalTest do
 
     assert_raise Error, fn ->
       Decimal.div_int(~d"0", ~d"-0")
+    end
+
+    assert_raise Error, fn ->
+      Decimal.div_int(~d"-1", ~d"0")
     end
   end
 
@@ -373,6 +380,7 @@ defmodule DecimalTest do
     assert Decimal.rem(~d"-inf", ~d"-2") == d(-1, 0, 0)
     assert Decimal.rem(~d"5", ~d"-inf") == d(1, :inf, 0)
     assert Decimal.rem(~d"nan", ~d"2") == d(1, :NaN, 0)
+    assert Decimal.rem(~d"1", ~d"nan") == d(1, :NaN, 0)
 
     assert_raise Error, fn ->
       Decimal.rem(~d"inf", ~d"inf")
@@ -380,6 +388,10 @@ defmodule DecimalTest do
 
     assert_raise Error, fn ->
       Decimal.rem(~d"0", ~d"-0")
+    end
+
+    assert_raise Error, fn ->
+      Decimal.rem(~d"-1", ~d"0")
     end
   end
 
@@ -476,7 +488,9 @@ defmodule DecimalTest do
     assert Decimal.mult(~d"0", ~d"-3") == d(-1, 0, 0)
 
     assert Decimal.mult(~d"inf", ~d"-3") == d(-1, :inf, 0)
+    assert Decimal.mult(~d"-3", ~d"inf") == d(-1, :inf, 0)
     assert Decimal.mult(~d"nan", ~d"2") == d(1, :NaN, 0)
+    assert Decimal.mult(~d"2", ~d"nan") == d(1, :NaN, 0)
 
     assert_raise Error, fn ->
       Decimal.mult(~d"inf", ~d"0")
@@ -742,6 +756,12 @@ defmodule DecimalTest do
       assert Decimal.sqrt(~d"10") == d(1, 316_227_766, -8)
       assert Decimal.sqrt(~d"7") == d(1, 264_575_131, -8)
       assert Decimal.sqrt(~d"0.39") == d(1, 624_499_800, -9)
+
+      assert_raise Decimal.Error, fn ->
+        Decimal.sqrt(~d"NaN")
+      end
+
+      assert Decimal.sqrt(~d"Infinity") == ~d"Infinity"
     end)
   end
 
@@ -871,6 +891,10 @@ defmodule DecimalTest do
 
     assert_raise Decimal.Error, fn ->
       Decimal.round(d(-1, -1, -1), 1, :half_up)
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.normalize(%Decimal{coef: -1})
     end
 
     # mult
@@ -1079,5 +1103,19 @@ defmodule DecimalTest do
 
   test "test Decimal.new/3" do
     assert Decimal.new(-1, 3, 2) == d(-1, 3, 2)
+  end
+
+  test "test Decimal.div_rem - quotient too large" do
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_rem(123_456_789_012_345_678_901_234_567_890, 5)
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_rem(~d"Infinity", ~d"Infinity")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_rem(~d"0", ~d"0")
+    end
   end
 end

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -181,7 +181,6 @@ defmodule DecimalTest do
     assert Decimal.add(~d"-0", ~d"0") == d(1, 0, 0)
     assert Decimal.add(~d"-0", ~d"-0") == d(-1, 0, 0)
     assert Decimal.add(~d"2", ~d"-2") == d(1, 0, 0)
-    assert Decimal.add(~d"NaN", ~d"1") == d(1, :NaN, 0)
     assert Decimal.add(~d"5", ~d"nan") == d(1, :NaN, 0)
     assert Decimal.add(~d"inf", ~d"inf") == d(1, :inf, 0)
     assert Decimal.add(~d"-inf", ~d"-inf") == d(-1, :inf, 0)
@@ -309,7 +308,6 @@ defmodule DecimalTest do
     assert Decimal.div(~d"-0", ~d"3") == d(-1, 0, 0)
     assert Decimal.div(~d"0", ~d"-3") == d(-1, 0, 0)
     assert Decimal.div(~d"nan", ~d"2") == d(1, :NaN, 0)
-    assert Decimal.div(~d"1", ~d"NaN") == d(1, :NaN, 0)
 
     assert Decimal.div(~d"-inf", ~d"-2") == d(1, :inf, 0)
     assert Decimal.div(~d"5", ~d"-inf") == d(-1, 0, 0)
@@ -342,7 +340,6 @@ defmodule DecimalTest do
     assert Decimal.div_int(~d"-0", ~d"3") == d(-1, 0, 0)
     assert Decimal.div_int(~d"0", ~d"-3") == d(-1, 0, 0)
     assert Decimal.div_int(~d"nan", ~d"2") == d(1, :NaN, 0)
-    assert Decimal.div_int(~d"1", ~d"NaN") == d(1, :NaN, 0)
 
     assert Decimal.div_int(~d"-inf", ~d"-2") == d(1, :inf, 0)
     assert Decimal.div_int(~d"5", ~d"-inf") == d(-1, 0, 0)
@@ -353,10 +350,6 @@ defmodule DecimalTest do
 
     assert_raise Error, fn ->
       Decimal.div_int(~d"0", ~d"-0")
-    end
-
-    assert_raise Error, fn ->
-      Decimal.div_int(~d"-1", ~d"0")
     end
   end
 
@@ -380,7 +373,6 @@ defmodule DecimalTest do
     assert Decimal.rem(~d"-inf", ~d"-2") == d(-1, 0, 0)
     assert Decimal.rem(~d"5", ~d"-inf") == d(1, :inf, 0)
     assert Decimal.rem(~d"nan", ~d"2") == d(1, :NaN, 0)
-    assert Decimal.rem(~d"1", ~d"nan") == d(1, :NaN, 0)
 
     assert_raise Error, fn ->
       Decimal.rem(~d"inf", ~d"inf")
@@ -388,10 +380,6 @@ defmodule DecimalTest do
 
     assert_raise Error, fn ->
       Decimal.rem(~d"0", ~d"-0")
-    end
-
-    assert_raise Error, fn ->
-      Decimal.rem(~d"-1", ~d"0")
     end
   end
 
@@ -488,9 +476,7 @@ defmodule DecimalTest do
     assert Decimal.mult(~d"0", ~d"-3") == d(-1, 0, 0)
 
     assert Decimal.mult(~d"inf", ~d"-3") == d(-1, :inf, 0)
-    assert Decimal.mult(~d"-3", ~d"inf") == d(-1, :inf, 0)
     assert Decimal.mult(~d"nan", ~d"2") == d(1, :NaN, 0)
-    assert Decimal.mult(~d"2", ~d"nan") == d(1, :NaN, 0)
 
     assert_raise Error, fn ->
       Decimal.mult(~d"inf", ~d"0")
@@ -756,12 +742,6 @@ defmodule DecimalTest do
       assert Decimal.sqrt(~d"10") == d(1, 316_227_766, -8)
       assert Decimal.sqrt(~d"7") == d(1, 264_575_131, -8)
       assert Decimal.sqrt(~d"0.39") == d(1, 624_499_800, -9)
-
-      assert_raise Decimal.Error, fn ->
-        Decimal.sqrt(~d"NaN")
-      end
-
-      assert Decimal.sqrt(~d"Infinity") == ~d"Infinity"
     end)
   end
 
@@ -876,100 +856,6 @@ defmodule DecimalTest do
     assert_raise Decimal.Error, fn ->
       Decimal.to_string(d(-1, -1, -1))
     end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.sqrt(d(1, -1, -1))
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.round(d(-1, -1, -1))
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.round(d(-1, -1, -1), 1)
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.round(d(-1, -1, -1), 1, :half_up)
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.normalize(%Decimal{coef: -1})
-    end
-
-    # mult
-    assert_raise Decimal.Error, fn ->
-      Decimal.mult(d(-1, -1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.mult(~d"1", d(-1, -1, -1))
-    end
-
-    # div_rem
-    assert_raise Decimal.Error, fn ->
-      Decimal.div_rem(d(-1, -1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.div_rem(~d"1", d(-1, -1, -1))
-    end
-
-    # rem
-    assert_raise Decimal.Error, fn ->
-      Decimal.rem(d(-1, -1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.rem(~d"1", d(-1, -1, -1))
-    end
-
-    # div_int
-    assert_raise Decimal.Error, fn ->
-      Decimal.div_int(d(-1, -1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.div_int(~d"1", d(-1, -1, -1))
-    end
-
-    # div
-    assert_raise Decimal.Error, fn ->
-      Decimal.div(d(-1, -1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.div(~d"1", d(-1, -1, -1))
-    end
-
-    # compare
-    assert_raise Decimal.Error, fn ->
-      Decimal.compare(d(-1, -1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.compare(~d"1", d(-1, -1, -1))
-    end
-
-    # sub
-    assert_raise Decimal.Error, fn ->
-      Decimal.sub(d(-1, -1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.sub(~d"1", d(-1, -1, -1))
-    end
-
-    # add
-    assert_raise Decimal.Error, fn ->
-      Decimal.add(d(-1, -1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.add(~d"1", d(-1, -1, -1))
-    end
-
-    assert inspect(d(-1, -1, -1)) =~ "Decimal.Error"
   end
 
   test "issue wrong sign value" do
@@ -992,130 +878,20 @@ defmodule DecimalTest do
     assert_raise Decimal.Error, fn ->
       Decimal.to_string(d(-300, 1, -1))
     end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.sqrt(d(300, 1, -1))
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.round(d(-300, 1, -1))
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.round(d(-300, 1, -1), 1)
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.round(d(-300, 1, -1), 1, :half_up)
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.normalize(%Decimal{sign: -300})
-    end
-
-    # mult
-    assert_raise Decimal.Error, fn ->
-      Decimal.mult(d(-300, 1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.mult(~d"1", d(-300, 1, -1))
-    end
-
-    # div_rem
-    assert_raise Decimal.Error, fn ->
-      Decimal.div_rem(d(-300, 1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.div_rem(~d"1", d(-300, 1, -1))
-    end
-
-    # rem
-    assert_raise Decimal.Error, fn ->
-      Decimal.rem(d(-300, 1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.rem(~d"1", d(-300, 1, -1))
-    end
-
-    # div_int
-    assert_raise Decimal.Error, fn ->
-      Decimal.div_int(d(-300, 1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.div_int(~d"1", d(-300, 1, -1))
-    end
-
-    # div
-    assert_raise Decimal.Error, fn ->
-      Decimal.div(d(-300, 1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.div(~d"1", d(-300, 1, -1))
-    end
-
-    # compare
-    assert_raise Decimal.Error, fn ->
-      Decimal.compare(d(-300, 1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.compare(~d"1", d(-300, 1, -1))
-    end
-
-    # sub
-    assert_raise Decimal.Error, fn ->
-      Decimal.sub(d(-300, 1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.sub(~d"1", d(-300, 1, -1))
-    end
-
-    # add
-    assert_raise Decimal.Error, fn ->
-      Decimal.add(d(-300, 1, -1), ~d"1")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.add(~d"1", d(-300, 1, -1))
-    end
-
-    assert inspect(d(-300, 1, 1)) =~ "Decimal.Error"
-    assert inspect(d(300, -1, 1)) =~ "Decimal.Error"
   end
 
-  test "test wrong exp value" do
-    assert_raise Decimal.Error, fn ->
-      Decimal.new(%Decimal{exp: 3.3})
-    end
+  test "test new cast handling" do
+    assert Decimal.cast(d(3, 123, 0)) == :error
+    assert Decimal.cast(d(1, -123, 0)) == :error
+
+    assert Decimal.cast(d(3.1, 123, 0)) == :error
+    assert Decimal.cast(d(1, :atom, 0)) == :error
+    assert Decimal.cast(d(1, 123, "1")) == :error
   end
 
-  test "test sqrt negative value" do
+  test "test sqrt with wrong sign via new/1" do
     assert_raise Decimal.Error, fn ->
-      Decimal.sqrt(d(-1, 1, -1))
-    end
-  end
-
-  test "test Decimal.new/3" do
-    assert Decimal.new(-1, 3, 2) == d(-1, 3, 2)
-  end
-
-  test "test Decimal.div_rem - quotient too large" do
-    assert_raise Decimal.Error, fn ->
-      Decimal.div_rem(123_456_789_012_345_678_901_234_567_890, 5)
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.div_rem(~d"Infinity", ~d"Infinity")
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.div_rem(~d"0", ~d"0")
+      Decimal.sqrt(Decimal.new(d(3, 1, -1)))
     end
   end
 end

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -110,7 +110,7 @@ defmodule DecimalTest do
     assert Decimal.new(d(-1, 3, 2)) == d(-1, 3, 2)
     assert Decimal.new(123) == d(1, 123, 0)
 
-    assert_raise FunctionClauseError, fn ->
+    assert_raise Decimal.Error, fn ->
       Decimal.new(:atom)
     end
   end
@@ -834,5 +834,250 @@ defmodule DecimalTest do
     assert to_float.("0.8888888888888888888888") == 0.8888888888888888888888
     assert to_float.("0.9999999999999999") == 0.9999999999999999
     assert to_float.("0.99999999999999999") == 0.99999999999999999
+  end
+
+  test "issue negative coef" do
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(%Decimal{coef: -1})
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.to_integer(d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.to_float(d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.to_string(d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.sqrt(d(1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.round(d(-1, -1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.round(d(-1, -1, -1), 1)
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.round(d(-1, -1, -1), 1, :half_up)
+    end
+
+    # mult
+    assert_raise Decimal.Error, fn ->
+      Decimal.mult(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.mult(~d"1", d(-1, -1, -1))
+    end
+
+    # div_rem
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_rem(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_rem(~d"1", d(-1, -1, -1))
+    end
+
+    # rem
+    assert_raise Decimal.Error, fn ->
+      Decimal.rem(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.rem(~d"1", d(-1, -1, -1))
+    end
+
+    # div_int
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_int(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_int(~d"1", d(-1, -1, -1))
+    end
+
+    # div
+    assert_raise Decimal.Error, fn ->
+      Decimal.div(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div(~d"1", d(-1, -1, -1))
+    end
+
+    # compare
+    assert_raise Decimal.Error, fn ->
+      Decimal.compare(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.compare(~d"1", d(-1, -1, -1))
+    end
+
+    # sub
+    assert_raise Decimal.Error, fn ->
+      Decimal.sub(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.sub(~d"1", d(-1, -1, -1))
+    end
+
+    # add
+    assert_raise Decimal.Error, fn ->
+      Decimal.add(d(-1, -1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.add(~d"1", d(-1, -1, -1))
+    end
+
+    assert inspect(d(-1, -1, -1)) =~ "Decimal.Error"
+  end
+
+  test "issue wrong sign value" do
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(%Decimal{sign: -300})
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(d(-300, 1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.to_integer(d(-300, 1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.to_float(d(-300, 1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.to_string(d(-300, 1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.sqrt(d(300, 1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.round(d(-300, 1, -1))
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.round(d(-300, 1, -1), 1)
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.round(d(-300, 1, -1), 1, :half_up)
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.normalize(%Decimal{sign: -300})
+    end
+
+    # mult
+    assert_raise Decimal.Error, fn ->
+      Decimal.mult(d(-300, 1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.mult(~d"1", d(-300, 1, -1))
+    end
+
+    # div_rem
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_rem(d(-300, 1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_rem(~d"1", d(-300, 1, -1))
+    end
+
+    # rem
+    assert_raise Decimal.Error, fn ->
+      Decimal.rem(d(-300, 1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.rem(~d"1", d(-300, 1, -1))
+    end
+
+    # div_int
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_int(d(-300, 1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div_int(~d"1", d(-300, 1, -1))
+    end
+
+    # div
+    assert_raise Decimal.Error, fn ->
+      Decimal.div(d(-300, 1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.div(~d"1", d(-300, 1, -1))
+    end
+
+    # compare
+    assert_raise Decimal.Error, fn ->
+      Decimal.compare(d(-300, 1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.compare(~d"1", d(-300, 1, -1))
+    end
+
+    # sub
+    assert_raise Decimal.Error, fn ->
+      Decimal.sub(d(-300, 1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.sub(~d"1", d(-300, 1, -1))
+    end
+
+    # add
+    assert_raise Decimal.Error, fn ->
+      Decimal.add(d(-300, 1, -1), ~d"1")
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.add(~d"1", d(-300, 1, -1))
+    end
+
+    assert inspect(d(-300, 1, 1)) =~ "Decimal.Error"
+    assert inspect(d(300, -1, 1)) =~ "Decimal.Error"
+  end
+
+  test "test wrong exp value" do
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(%Decimal{exp: 3.3})
+    end
+  end
+
+  test "test sqrt negative value" do
+    assert_raise Decimal.Error, fn ->
+      Decimal.sqrt(d(-1, 1, -1))
+    end
+  end
+
+  test "test Decimal.new/3" do
+    assert Decimal.new(-1, 3, 2) == d(-1, 3, 2)
   end
 end


### PR DESCRIPTION
Hi,

I found a bug or structural problem in Decimal what could have some big impact under special circumstances. Here an example from the Money lib where Decimal is used as main backbone:

```elixir
iex(15)> m = Money.new(:USD, Decimal.new(%Decimal{sign: -1, coef: -12000000000}))
#Money<:USD, --12000000000>
iex(16)> Money.mult(m, 3)
{:ok, #Money<:USD, --36000000000>} 
iex(17)> Money.mult!(m, 3 )|> Money.to_string 
{:ok, "$--*,000,000,000.00"}
```

Of course it's a special edge case ... normally the best practice is:

```elixir
iex(18)> m = Money.new(:USD, "-12000000000") 
#Money<:USD, -12000000000>
```
but you never know ... maybe someone using it ...it's possible! it's valid Code ! 
NO compiler warning! (also true if you are using dialyzer, when using var names for input)
NO runtime error!

And the worst case, if you are using any division with this kind of Decimal number like this:

```elixir
iex(19)> m = Money.new(:USD, Decimal.new(%Decimal{sign: -1, coef: -12000000000}))
#Money<:USD, --12000000000>
iex(20)> Money.mult!(m, 3) |> Money.to_decimal |> Decimal.to_float
```
-> you end up in an infinite loop!!! 

The reason for this is clear: the %Decimal{} struct - with not enough validation for input -> so you can input a negative coefficient.

The type spec and docs are perfect - but do not prevent any misuse: 
Type spec :  
 @type coefficient :: non_neg_integer | :NaN | :inf
  @type sign :: 1 | -1

Documentation: The coefficient of the power of `10`. Non-negative because the sign is stored separately in `sign`.

So my suggestion for a solution you can find in this pull request: mostly checks for this special edge case.

And this time I included the corresponding tests. ;-) 

one example for the additional function clause (now backwards compatible to Elixir 1.2):
```elixir
def add(%Decimal{coef: coef1}, %Decimal{coef: coef2})
      when coef1 < 0 or coef2 < 0 do
    error(:invalid_operation, "wrong coef", %Decimal{coef: :NaN})
  end

  def add(%Decimal{sign: sign1}, %Decimal{})
      when sign1 != 1 and sign1 != -1 do
    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
  end

  def add(%Decimal{}, %Decimal{sign: sign2})
      when sign2 != 1 and sign2 != -1 do
    error(:invalid_operation, "wrong sign", %Decimal{coef: :NaN})
  end
```

The test and benchees are fine - no big performance cost - the differences are marginal (see deviation):

before the fix:

```elixir
##### With input 30 Digits Integer #####
Name                           ips        average  deviation         median         99th %
Decimal.add()    Int      318.01 K        3.14 μs   ±771.75%           3 μs           5 μs

Memory usage statistics:

Name                    Memory usage
Decimal.add()    Int         4.26 KB

**All measurements for memory usage were the same**

```

with the fix:
```elixir
##### With input 30 Digits Integer #####
Name                           ips        average  deviation         median         99th %
Decimal.add()    Int      316.97 K        3.15 μs   ±659.73%           3 μs           5 μs

Memory usage statistics:

Name                    Memory usage
Decimal.add()    Int         4.26 KB

**All measurements for memory usage were the same**

```