### PR TITLE
Macro check

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -156,8 +156,13 @@ defmodule Decimal do
         nil ->
           quote do
             case unquote(term) do
-              %_{} -> true
-              _ -> false
+              %_{sign: sign, coef: coef, exp: exp}
+              when sign in [1, -1] and ((is_integer(coef) and coef >= 0) or coef in [:NaN, :inf]) and
+                     is_integer(exp) ->
+                true
+
+              _ ->
+                false
             end
           end
 
@@ -169,7 +174,12 @@ defmodule Decimal do
         :guard ->
           quote do
             is_map(unquote(term)) and :erlang.is_map_key(:__struct__, unquote(term)) and
-              :erlang.map_get(:__struct__, unquote(term)) == Decimal
+              :erlang.map_get(:__struct__, unquote(term)) == Decimal and
+              :erlang.map_get(:sign, unquote(term)) in [1, -1] and
+              ((is_integer(:erlang.map_get(:coef, unquote(term))) and
+                  :erlang.map_get(:coef, unquote(term)) >= 0) or
+                 :erlang.map_get(:coef, unquote(term)) in [:NaN, :inf]) and
+              is_integer(:erlang.map_get(:exp, unquote(term)))
           end
       end
     end
@@ -178,8 +188,13 @@ defmodule Decimal do
     defmacro is_decimal(term) do
       quote do
         case unquote(term) do
-          %Decimal{} -> true
-          _ -> false
+          %Decimal{sign: sign, coef: coef, exp: exp}
+          when sign in [1, -1] and ((is_integer(coef) and coef >= 0) or coef in [:NaN, :inf]) and
+                 is_integer(exp) ->
+            true
+
+          _ ->
+            false
         end
       end
     end
@@ -1080,7 +1095,11 @@ defmodule Decimal do
       #Decimal<3.14>
   """
   @spec new(decimal) :: t
-  def new(%Decimal{} = num), do: num
+  def new(%Decimal{} = num) do
+    if is_decimal(num),
+      do: num,
+      else: raise(Error, reason: "wrong decimal number: #{inspect(num)}")
+  end
 
   def new(int) when is_integer(int),
     do: %Decimal{sign: if(int < 0, do: -1, else: 1), coef: Kernel.abs(int)}
@@ -1090,6 +1109,10 @@ defmodule Decimal do
       {decimal, ""} -> decimal
       _ -> raise Error, reason: "number parsing syntax: #{inspect(binary)}"
     end
+  end
+
+  def new(num) do
+    raise Error, reason: "wrong decimal number: #{inspect(num)}"
   end
 
   @doc """

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -91,6 +91,10 @@ defmodule DecimalTest do
     assert Decimal.is_decimal(~d"0")
     refute Decimal.is_decimal(42)
     refute Decimal.is_decimal("42")
+
+    refute Decimal.is_decimal(d(1, -1, 1))
+    refute Decimal.is_decimal(d(3, 1, 1))
+    refute Decimal.is_decimal(d(1, 1, 3.3))
   end
 
   if function_exported?(:erlang, :is_map_key, 2) do
@@ -103,6 +107,10 @@ defmodule DecimalTest do
       assert decimal?(~d"0")
       refute decimal?(42)
       refute decimal?("42")
+
+      refute decimal?(d(1, -1, 1))
+      refute decimal?(d(3, 1, 1))
+      refute decimal?(d(1, 1, 3.3))
     end
   end
 
@@ -110,7 +118,7 @@ defmodule DecimalTest do
     assert Decimal.new(d(-1, 3, 2)) == d(-1, 3, 2)
     assert Decimal.new(123) == d(1, 123, 0)
 
-    assert_raise FunctionClauseError, fn ->
+    assert_raise Decimal.Error, fn ->
       Decimal.new(:atom)
     end
   end
@@ -835,4 +843,42 @@ defmodule DecimalTest do
     assert to_float.("0.9999999999999999") == 0.9999999999999999
     assert to_float.("0.99999999999999999") == 0.99999999999999999
   end
+
+  test "issue negative coef" do
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(%Decimal{coef: -1})
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(d(-1, -1, -1))
+    end
+  end
+
+  test "issue wrong sign value" do
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(%Decimal{sign: -300})
+    end
+
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(d(-300, 1, -1))
+    end
+  end
+
+  test "issue wrong exp value" do
+    assert_raise Decimal.Error, fn ->
+      Decimal.new(d(1, 1, 3.3))
+    end
+  end
+
+  test "test sqrt with wrong sign via new/1" do
+    assert_raise Decimal.Error, fn ->
+      Decimal.sqrt(Decimal.new(d(3, 1, -1)))
+    end
+  end
+
+  # test "test sqrt with wrong sign -> infinite loop" do
+  #   assert_raise Decimal.Error, fn ->
+  #     Decimal.sqrt(d(3, 1, -1))
+  #   end
+  # end
 end

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -91,10 +91,6 @@ defmodule DecimalTest do
     assert Decimal.is_decimal(~d"0")
     refute Decimal.is_decimal(42)
     refute Decimal.is_decimal("42")
-
-    refute Decimal.is_decimal(d(1, -1, 1))
-    refute Decimal.is_decimal(d(3, 1, 1))
-    refute Decimal.is_decimal(d(1, 1, 3.3))
   end
 
   if function_exported?(:erlang, :is_map_key, 2) do
@@ -107,10 +103,6 @@ defmodule DecimalTest do
       assert decimal?(~d"0")
       refute decimal?(42)
       refute decimal?("42")
-
-      refute decimal?(d(1, -1, 1))
-      refute decimal?(d(3, 1, 1))
-      refute decimal?(d(1, 1, 3.3))
     end
   end
 
@@ -118,7 +110,7 @@ defmodule DecimalTest do
     assert Decimal.new(d(-1, 3, 2)) == d(-1, 3, 2)
     assert Decimal.new(123) == d(1, 123, 0)
 
-    assert_raise Decimal.Error, fn ->
+    assert_raise FunctionClauseError, fn ->
       Decimal.new(:atom)
     end
   end
@@ -844,41 +836,19 @@ defmodule DecimalTest do
     assert to_float.("0.99999999999999999") == 0.99999999999999999
   end
 
-  test "issue negative coef" do
-    assert_raise Decimal.Error, fn ->
+  test "issue wrong coef or sign value" do
+    assert_raise FunctionClauseError, fn ->
       Decimal.new(%Decimal{coef: -1})
     end
 
-    assert_raise Decimal.Error, fn ->
-      Decimal.new(d(-1, -1, -1))
-    end
-  end
-
-  test "issue wrong sign value" do
-    assert_raise Decimal.Error, fn ->
-      Decimal.new(%Decimal{sign: -300})
-    end
-
-    assert_raise Decimal.Error, fn ->
-      Decimal.new(d(-300, 1, -1))
-    end
-  end
-
-  test "issue wrong exp value" do
-    assert_raise Decimal.Error, fn ->
-      Decimal.new(d(1, 1, 3.3))
+    assert_raise FunctionClauseError, fn ->
+      Decimal.new(%Decimal{sign: -3})
     end
   end
 
   test "test sqrt with wrong sign via new/1" do
-    assert_raise Decimal.Error, fn ->
+    assert_raise FunctionClauseError, fn ->
       Decimal.sqrt(Decimal.new(d(3, 1, -1)))
     end
   end
-
-  # test "test sqrt with wrong sign -> infinite loop" do
-  #   assert_raise Decimal.Error, fn ->
-  #     Decimal.sqrt(d(3, 1, -1))
-  #   end
-  # end
 end


### PR DESCRIPTION
Thanks for the macro idea @wojtekmach !

I hope that's what you mean.

Not all edge cases are fixed, but the most important ones for the inbound (see tests).

The normal way for current Elixir Version would be:

```elixir
def new(%Decimal{} = num) when is_decimal(num), do: num
```

But thats not working with Elixir 1.2.6 - thats why:

```elixir
  def new(%Decimal{} = num) do
    if is_decimal(num),
      do: num,
      else: raise(Error, reason: "wrong decimal number: #{inspect(num)}")
  end
```
Any other idea for 1.2.6? ;-)
 
I really appreciate your help with all of this!

btw. this PR would fix the Money problem:

```elixir
iex(1)> m = Money.new(:USD, Decimal.new(%Decimal{sign: -1, coef: -12000000000}))
** (Decimal.Error) : wrong decimal number: #Decimal<--12000000000>
    (decimal 1.8.1) lib/decimal.ex:1101: Decimal.new/1
```