### PR TITLE
Implicit conversion

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1702,7 +1702,7 @@ defmodule Decimal do
 
   # Util
 
-  defp decimal(%Decimal{} = num), do: num
+  defp decimal(%Decimal{} = num), do: new(num)
   defp decimal(num) when is_integer(num), do: new(num)
   defp decimal(num) when is_binary(num), do: new(num)
 

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -848,9 +848,9 @@ defmodule DecimalTest do
     end
   end
 
-  test "test sqrt with wrong sign via new/1" do
+  test "test sqrt with wrong decimal -> infinite loop" do
     assert_raise FunctionClauseError, fn ->
-      Decimal.sqrt(Decimal.new(d(3, 1, -1)))
+      Decimal.sqrt(d(3, 1, -1))
     end
   end
 end


### PR DESCRIPTION
@ericmj wrote:

> This change helps in your money example because you pass the manually crafted struct to `Decimal.new/1` but that's unnecessary since it's a noop. So it would only help if the user is doing unnecessary function calls.

Yes you are right my test is a noop! It's always important to write good tests and reading the hints of others too. ;-) thanks for that! 

Without new/1 it's still going into the infinite loop and I did'nt look deeper into it because I was dazzled by the evidend looking reason.

So the real reason for the infinite loop will be clear with correct test :

The most public functions have a fallback function clause for handling implicite conversion with the private function decimal/1 - like sqrt:

```elixir
  def sqrt(num) do
    sqrt(decimal(num))
  end
```

but this decimal/1 has no "exit" function clause:

```elixir
  defp decimal(%Decimal{} = num), do: num
  defp decimal(num) when is_integer(num), do: new(num)
  defp decimal(num) when is_binary(num), do: new(num)

  defp decimal(other) when is_float(other) do
    raise ArgumentError,
          "implicit conversion of #{inspect(other)} to Decimal is not allowed. Use Decimal.from_float/1"
  end
```

that means in the VERY UNCOMMON event!!! of my test (not noop!) :

```elixir
  test "test sqrt with wrong sign" do
    assert_raise FunctionClauseError, fn ->
      Decimal.sqrt(d(3, 1, -1))
    end
  end
```

it will stuck in that infinite loop of function calls between both.

So after we have that "let it crash" in new/1 we could handle this with an easy forward to new/1:

```elixir
  defp decimal(%Decimal{} = num), do: new(num)
```

What do you think - sounds reasonable too? 

Thanks!