### PR TITLE
Add Decimal.cast!/1

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1175,6 +1175,24 @@ defmodule Decimal do
   def cast(_), do: :error
 
   @doc """
+  Creates a new decimal number using `Decimal.cast/1` and raises error when input could not be converted to decimal number.
+
+  ## Examples
+
+      iex> decimal = Decimal.cast!(3)
+      iex> decimal
+      #Decimal<3>
+
+  """
+  @spec cast!(term) :: t
+  def cast!(value) do
+    case cast(value) do
+      {:ok, decimal} -> decimal
+      _ -> raise Error, reason: "could not cast #{inspect(value)}"
+    end
+  end
+
+  @doc """
   Parses a binary into a decimal.
 
   If successful, returns a tuple in the form of `{decimal, remainder_of_binary}`,

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -165,6 +165,17 @@ defmodule DecimalTest do
     assert Decimal.cast(:one_two_three) == :error
   end
 
+  test "cast!/1" do
+    assert Decimal.cast!(123) == d(1, 123, 0)
+    assert Decimal.cast!(123.0) == d(1, 1230, -1)
+    assert Decimal.cast!("123") == d(1, 123, 0)
+    assert Decimal.cast!(d(1, 123, 0)) == d(1, 123, 0)
+
+    assert_raise Error, fn -> Decimal.cast!("one two three") end
+    assert_raise Error, fn -> Decimal.cast!("e0") end
+    assert_raise Error, fn -> Decimal.cast!(:one_two_three) end
+  end
+
   test "abs/1" do
     assert Decimal.abs(~d"123") == d(1, 123, 0)
     assert Decimal.abs(~d"-123") == d(1, 123, 0)


### PR DESCRIPTION
Adds `Decimal.cast!/1` method for easier piping. This functionality is similar to `Decimal.cast/1` behaviour from 1.8.1:

```elixir
"3.1400" |> Decimal.cast!() |> Decimal.normalize()
```

Returns Decimal without `:ok` tuple on success, but throws error if input could not be converted to Decimal.