### PR TITLE
Implemented guards to make Decimal easily handable alongside numbers

### DIFF
--- a/lib/decimal/guards.ex
+++ b/lib/decimal/guards.ex
@@ -1,7 +1,11 @@
 if Version.compare(System.version(), "1.11.0") != :lt do
   if String.to_integer(apply(System, :otp_release, [])) > 22 do
     defmodule Decimal.Guards do
-      @moduledoc since: "2.1.0"
+      import Decimal.Macros
+
+      if Version.match?(System.version(), ">= 1.11.0") do
+        @moduledoc since: "2.1.0"
+      end
       @moduledoc """
       Set of guards allowing validating `Decimal` values in guards.
 
@@ -16,7 +20,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       :ok
       """
 
-      @doc since: "2.1.0"
+      doc_since("2.1.0")
       @doc """
       Returns `true` if term is a `Decimal`; otherwise returns `false`.
 
@@ -30,7 +34,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       """
       defguard is_decimal(d) when is_map(d) and d.__struct__ == Decimal
 
-      @doc since: "2.1.0"
+      doc_since("2.1.0")
       @doc """
       Returns `true` if term is a `Decimal` and is non-negative; otherwise returns `false`.
 
@@ -44,7 +48,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       """
       defguard is_decimal_non_negative(d) when is_decimal(d) and d.sign == 1
 
-      @doc since: "2.1.0"
+      doc_since("2.1.0")
       @doc """
       Returns `true` if term is a `Decimal` and is positive; otherwise returns `false`.
 
@@ -59,7 +63,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       """
       defguard is_decimal_positive(d) when is_decimal_non_negative(d) and d.coef != 0
 
-      @doc since: "2.1.0"
+      doc_since("2.1.0")
       @doc """
       Returns `true` if term is a `Decimal` and is negative; otherwise returns `false`.
 
@@ -73,7 +77,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       """
       defguard is_decimal_negative(d) when is_decimal(d) and d.sign == -1
 
-      @doc since: "2.1.0"
+      doc_since("2.1.0")
       @doc """
       Returns `true` if term is a `Decimal` and is non-negative; otherwise returns `false`.
 
@@ -90,7 +94,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       defguard is_non_negative(d)
                when is_decimal_non_negative(d) or ((is_integer(d) or is_float(d)) and d >= 0)
 
-      @doc since: "2.1.0"
+      doc_since("2.1.0")
       @doc """
       Returns `true` if term is a `Decimal` and is positive; otherwise returns `false`.
 
@@ -107,7 +111,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       defguard is_positive(d)
                when is_decimal_positive(d) or ((is_integer(d) or is_float(d)) and d > 0)
 
-      @doc since: "2.1.0"
+      doc_since("2.1.0")
       @doc """
       Returns `true` if term is a `Decimal` and is negative; otherwise returns `false`.
 

--- a/lib/decimal/guards.ex
+++ b/lib/decimal/guards.ex
@@ -1,0 +1,125 @@
+if String.to_integer(System.otp_release()) > 22 and
+     Version.compare(System.version(), "1.11.0") != :lt do
+  defmodule Decimal.Guards do
+    @moduledoc since: "2.1.0"
+    @moduledoc """
+    Set of guards allowing validating `Decimal` values in guards.
+
+    ## Examples
+
+    iex> case {"1", Decimal.cast("1")} do
+    ...>   {s, {:ok, d}} when is_decimal_positive(d) and not is_decimal(s) -> :ok
+    ...>   _ -> :error
+    ...> end
+    :ok
+    """
+
+    @doc since: "2.1.0"
+    @doc """
+    Returns `true` if term is a `Decimal`; otherwise returns `false`.
+
+    ## Examples
+
+    iex> case Decimal.cast("1") do
+    ...>   {:ok, d} when is_decimal(d) -> :ok
+    ...>   _ -> :error
+    ...> end
+    :ok
+    """
+    defguard is_decimal(d) when is_map(d) and d.__struct__ == Decimal
+
+    @doc since: "2.1.0"
+    @doc """
+    Returns `true` if term is a `Decimal` and is non-negative; otherwise returns `false`.
+
+    ## Examples
+
+    iex> case Decimal.cast("0") do
+    ...>   {:ok, d} when is_decimal_non_negative(d) -> :ok
+    ...>   _ -> :error
+    ...> end
+    :ok
+    """
+    defguard is_decimal_non_negative(d) when is_decimal(d) and d.sign == 1
+
+    @doc since: "2.1.0"
+    @doc """
+    Returns `true` if term is a `Decimal` and is positive; otherwise returns `false`.
+
+    ## Examples
+
+    iex> case {Decimal.cast("1"), Decimal.cast("0")} do
+    ...>   {{:ok, d1}, {:ok, d2}} when is_decimal_positive(d1) and
+    ...>                               not is_decimal_positive(d2) -> :ok
+    ...>   _ -> :error
+    ...> end
+    :ok
+    """
+    defguard is_decimal_positive(d) when is_decimal_non_negative(d) and d.coef != 0
+
+    @doc since: "2.1.0"
+    @doc """
+    Returns `true` if term is a `Decimal` and is negative; otherwise returns `false`.
+
+    ## Examples
+
+    iex> case Decimal.cast("-1") do
+    ...>   {:ok, d} when is_decimal_negative(d) -> :ok
+    ...>   _ -> :error
+    ...> end
+    :ok
+    """
+    defguard is_decimal_negative(d) when is_decimal(d) and d.sign == -1
+
+    @doc since: "2.1.0"
+    @doc """
+    Returns `true` if term is a `Decimal` and is non-negative; otherwise returns `false`.
+
+    ## Examples
+
+    iex> case {0, Decimal.cast("1"), "1"} do
+    ...>   {i, {:ok, d}, s} when is_non_negative(d)
+    ...>                         and is_non_negative(i)
+    ...>                         and not is_non_negative(s) -> :ok
+    ...>   _ -> :error
+    ...> end
+    :ok
+    """
+    defguard is_non_negative(d)
+             when is_decimal_non_negative(d) or ((is_integer(d) or is_float(d)) and d >= 0)
+
+    @doc since: "2.1.0"
+    @doc """
+    Returns `true` if term is a `Decimal` and is positive; otherwise returns `false`.
+
+    ## Examples
+
+    iex> case {0, Decimal.cast("1"), "1"} do
+    ...>   {i, {:ok, d}, s} when is_positive(d)
+    ...>                         and not is_positive(i)
+    ...>                         and not is_positive(s) -> :ok
+    ...>   _ -> :error
+    ...> end
+    :ok
+    """
+    defguard is_positive(d)
+             when is_decimal_positive(d) or ((is_integer(d) or is_float(d)) and d > 0)
+
+    @doc since: "2.1.0"
+    @doc """
+    Returns `true` if term is a `Decimal` and is negative; otherwise returns `false`.
+
+    ## Examples
+
+    iex> case {-1, Decimal.cast("-1"), "-1"} do
+    ...>   {i, {:ok, d}, s} when is_negative(d)
+    ...>                         and is_negative(i)
+    ...>                         and not is_negative(s) -> :ok
+    ...>   _ -> :error
+    ...> end
+    :ok
+    """
+    defguard is_negative(d)
+             when is_decimal_negative(d) or ((is_integer(d) or is_float(d)) and d < 0)
+  end
+end

--- a/lib/decimal/guards.ex
+++ b/lib/decimal/guards.ex
@@ -1,5 +1,5 @@
 if Version.compare(System.version(), "1.11.0") != :lt do
-  if String.to_integer(System.otp_release()) > 22 do
+  if String.to_integer(apply(System, :otp_release, [])) > 22 do
     defmodule Decimal.Guards do
       @moduledoc since: "2.1.0"
       @moduledoc """

--- a/lib/decimal/guards.ex
+++ b/lib/decimal/guards.ex
@@ -1,125 +1,128 @@
-if String.to_integer(System.otp_release()) > 22 and
-     Version.compare(System.version(), "1.11.0") != :lt do
-  defmodule Decimal.Guards do
-    @moduledoc since: "2.1.0"
-    @moduledoc """
-    Set of guards allowing validating `Decimal` values in guards.
+if Version.compare(System.version(), "1.11.0") != :lt do
+  if String.to_integer(System.otp_release()) > 22 do
+    defmodule Decimal.Guards do
+      @moduledoc since: "2.1.0"
+      @moduledoc """
+      Set of guards allowing validating `Decimal` values in guards.
 
-    ## Examples
+      Use `import Decimal.Guards` to use these guards in your module.
 
-    iex> case {"1", Decimal.cast("1")} do
-    ...>   {s, {:ok, d}} when is_decimal_positive(d) and not is_decimal(s) -> :ok
-    ...>   _ -> :error
-    ...> end
-    :ok
-    """
+      ## Examples
 
-    @doc since: "2.1.0"
-    @doc """
-    Returns `true` if term is a `Decimal`; otherwise returns `false`.
+      iex> case {"1", Decimal.cast("1")} do
+      ...>   {s, {:ok, d}} when is_decimal_positive(d) and not is_decimal(s) -> :ok
+      ...>   _ -> :error
+      ...> end
+      :ok
+      """
 
-    ## Examples
+      @doc since: "2.1.0"
+      @doc """
+      Returns `true` if term is a `Decimal`; otherwise returns `false`.
 
-    iex> case Decimal.cast("1") do
-    ...>   {:ok, d} when is_decimal(d) -> :ok
-    ...>   _ -> :error
-    ...> end
-    :ok
-    """
-    defguard is_decimal(d) when is_map(d) and d.__struct__ == Decimal
+      ## Examples
 
-    @doc since: "2.1.0"
-    @doc """
-    Returns `true` if term is a `Decimal` and is non-negative; otherwise returns `false`.
+      iex> case Decimal.cast("1") do
+      ...>   {:ok, d} when is_decimal(d) -> :ok
+      ...>   _ -> :error
+      ...> end
+      :ok
+      """
+      defguard is_decimal(d) when is_map(d) and d.__struct__ == Decimal
 
-    ## Examples
+      @doc since: "2.1.0"
+      @doc """
+      Returns `true` if term is a `Decimal` and is non-negative; otherwise returns `false`.
 
-    iex> case Decimal.cast("0") do
-    ...>   {:ok, d} when is_decimal_non_negative(d) -> :ok
-    ...>   _ -> :error
-    ...> end
-    :ok
-    """
-    defguard is_decimal_non_negative(d) when is_decimal(d) and d.sign == 1
+      ## Examples
 
-    @doc since: "2.1.0"
-    @doc """
-    Returns `true` if term is a `Decimal` and is positive; otherwise returns `false`.
+      iex> case Decimal.cast("0") do
+      ...>   {:ok, d} when is_decimal_non_negative(d) -> :ok
+      ...>   _ -> :error
+      ...> end
+      :ok
+      """
+      defguard is_decimal_non_negative(d) when is_decimal(d) and d.sign == 1
 
-    ## Examples
+      @doc since: "2.1.0"
+      @doc """
+      Returns `true` if term is a `Decimal` and is positive; otherwise returns `false`.
 
-    iex> case {Decimal.cast("1"), Decimal.cast("0")} do
-    ...>   {{:ok, d1}, {:ok, d2}} when is_decimal_positive(d1) and
-    ...>                               not is_decimal_positive(d2) -> :ok
-    ...>   _ -> :error
-    ...> end
-    :ok
-    """
-    defguard is_decimal_positive(d) when is_decimal_non_negative(d) and d.coef != 0
+      ## Examples
 
-    @doc since: "2.1.0"
-    @doc """
-    Returns `true` if term is a `Decimal` and is negative; otherwise returns `false`.
+      iex> case {Decimal.cast("1"), Decimal.cast("0")} do
+      ...>   {{:ok, d1}, {:ok, d2}} when is_decimal_positive(d1) and
+      ...>                               not is_decimal_positive(d2) -> :ok
+      ...>   _ -> :error
+      ...> end
+      :ok
+      """
+      defguard is_decimal_positive(d) when is_decimal_non_negative(d) and d.coef != 0
 
-    ## Examples
+      @doc since: "2.1.0"
+      @doc """
+      Returns `true` if term is a `Decimal` and is negative; otherwise returns `false`.
 
-    iex> case Decimal.cast("-1") do
-    ...>   {:ok, d} when is_decimal_negative(d) -> :ok
-    ...>   _ -> :error
-    ...> end
-    :ok
-    """
-    defguard is_decimal_negative(d) when is_decimal(d) and d.sign == -1
+      ## Examples
 
-    @doc since: "2.1.0"
-    @doc """
-    Returns `true` if term is a `Decimal` and is non-negative; otherwise returns `false`.
+      iex> case Decimal.cast("-1") do
+      ...>   {:ok, d} when is_decimal_negative(d) -> :ok
+      ...>   _ -> :error
+      ...> end
+      :ok
+      """
+      defguard is_decimal_negative(d) when is_decimal(d) and d.sign == -1
 
-    ## Examples
+      @doc since: "2.1.0"
+      @doc """
+      Returns `true` if term is a `Decimal` and is non-negative; otherwise returns `false`.
 
-    iex> case {0, Decimal.cast("1"), "1"} do
-    ...>   {i, {:ok, d}, s} when is_non_negative(d)
-    ...>                         and is_non_negative(i)
-    ...>                         and not is_non_negative(s) -> :ok
-    ...>   _ -> :error
-    ...> end
-    :ok
-    """
-    defguard is_non_negative(d)
-             when is_decimal_non_negative(d) or ((is_integer(d) or is_float(d)) and d >= 0)
+      ## Examples
 
-    @doc since: "2.1.0"
-    @doc """
-    Returns `true` if term is a `Decimal` and is positive; otherwise returns `false`.
+      iex> case {0, Decimal.cast("1"), "1"} do
+      ...>   {i, {:ok, d}, s} when is_non_negative(d)
+      ...>                         and is_non_negative(i)
+      ...>                         and not is_non_negative(s) -> :ok
+      ...>   _ -> :error
+      ...> end
+      :ok
+      """
+      defguard is_non_negative(d)
+               when is_decimal_non_negative(d) or ((is_integer(d) or is_float(d)) and d >= 0)
 
-    ## Examples
+      @doc since: "2.1.0"
+      @doc """
+      Returns `true` if term is a `Decimal` and is positive; otherwise returns `false`.
 
-    iex> case {0, Decimal.cast("1"), "1"} do
-    ...>   {i, {:ok, d}, s} when is_positive(d)
-    ...>                         and not is_positive(i)
-    ...>                         and not is_positive(s) -> :ok
-    ...>   _ -> :error
-    ...> end
-    :ok
-    """
-    defguard is_positive(d)
-             when is_decimal_positive(d) or ((is_integer(d) or is_float(d)) and d > 0)
+      ## Examples
 
-    @doc since: "2.1.0"
-    @doc """
-    Returns `true` if term is a `Decimal` and is negative; otherwise returns `false`.
+      iex> case {0, Decimal.cast("1"), "1"} do
+      ...>   {i, {:ok, d}, s} when is_positive(d)
+      ...>                         and not is_positive(i)
+      ...>                         and not is_positive(s) -> :ok
+      ...>   _ -> :error
+      ...> end
+      :ok
+      """
+      defguard is_positive(d)
+               when is_decimal_positive(d) or ((is_integer(d) or is_float(d)) and d > 0)
 
-    ## Examples
+      @doc since: "2.1.0"
+      @doc """
+      Returns `true` if term is a `Decimal` and is negative; otherwise returns `false`.
 
-    iex> case {-1, Decimal.cast("-1"), "-1"} do
-    ...>   {i, {:ok, d}, s} when is_negative(d)
-    ...>                         and is_negative(i)
-    ...>                         and not is_negative(s) -> :ok
-    ...>   _ -> :error
-    ...> end
-    :ok
-    """
-    defguard is_negative(d)
-             when is_decimal_negative(d) or ((is_integer(d) or is_float(d)) and d < 0)
+      ## Examples
+
+      iex> case {-1, Decimal.cast("-1"), "-1"} do
+      ...>   {i, {:ok, d}, s} when is_negative(d)
+      ...>                         and is_negative(i)
+      ...>                         and not is_negative(s) -> :ok
+      ...>   _ -> :error
+      ...> end
+      :ok
+      """
+      defguard is_negative(d)
+               when is_decimal_negative(d) or ((is_integer(d) or is_float(d)) and d < 0)
+    end
   end
 end

--- a/lib/decimal/guards.ex
+++ b/lib/decimal/guards.ex
@@ -6,6 +6,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       if Version.match?(System.version(), ">= 1.11.0") do
         @moduledoc since: "2.1.0"
       end
+
       @moduledoc """
       Set of guards allowing validating `Decimal` values in guards.
 
@@ -21,6 +22,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       """
 
       doc_since("2.1.0")
+
       @doc """
       Returns `true` if term is a `Decimal`; otherwise returns `false`.
 
@@ -35,6 +37,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       defguard is_decimal(d) when is_map(d) and d.__struct__ == Decimal
 
       doc_since("2.1.0")
+
       @doc """
       Returns `true` if term is a `Decimal` and is non-negative; otherwise returns `false`.
 
@@ -49,6 +52,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       defguard is_decimal_non_negative(d) when is_decimal(d) and d.sign == 1
 
       doc_since("2.1.0")
+
       @doc """
       Returns `true` if term is a `Decimal` and is positive; otherwise returns `false`.
 
@@ -64,6 +68,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       defguard is_decimal_positive(d) when is_decimal_non_negative(d) and d.coef != 0
 
       doc_since("2.1.0")
+
       @doc """
       Returns `true` if term is a `Decimal` and is negative; otherwise returns `false`.
 
@@ -78,6 +83,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
       defguard is_decimal_negative(d) when is_decimal(d) and d.sign == -1
 
       doc_since("2.1.0")
+
       @doc """
       Returns `true` if term is a `Decimal` and is non-negative; otherwise returns `false`.
 
@@ -95,6 +101,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
                when is_decimal_non_negative(d) or ((is_integer(d) or is_float(d)) and d >= 0)
 
       doc_since("2.1.0")
+
       @doc """
       Returns `true` if term is a `Decimal` and is positive; otherwise returns `false`.
 
@@ -112,6 +119,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
                when is_decimal_positive(d) or ((is_integer(d) or is_float(d)) and d > 0)
 
       doc_since("2.1.0")
+
       @doc """
       Returns `true` if term is a `Decimal` and is negative; otherwise returns `false`.
 

--- a/lib/decimal/guards.ex
+++ b/lib/decimal/guards.ex
@@ -3,9 +3,7 @@ if Version.compare(System.version(), "1.11.0") != :lt do
     defmodule Decimal.Guards do
       import Decimal.Macros
 
-      if Version.match?(System.version(), ">= 1.11.0") do
-        @moduledoc since: "2.1.0"
-      end
+      @moduledoc since: "2.1.0"
 
       @moduledoc """
       Set of guards allowing validating `Decimal` values in guards.

--- a/test/decimal/guards_test.exs
+++ b/test/decimal/guards_test.exs
@@ -1,11 +1,12 @@
-if String.to_integer(System.otp_release()) > 22 and
-     Version.compare(System.version(), "1.11.0") != :lt do
-  defmodule DecimalGuardsTest do
-    use ExUnit.Case, async: true
+if Version.compare(System.version(), "1.11.0") != :lt do
+  if String.to_integer(apply(System, :otp_release, [])) > 22 do
+    defmodule DecimalGuardsTest do
+      use ExUnit.Case, async: true
 
-    require Decimal
-    import Decimal.Guards
+      require Decimal
+      import Decimal.Guards
 
-    doctest Decimal.Guards
+      doctest Decimal.Guards
+    end
   end
 end

--- a/test/decimal/guards_test.exs
+++ b/test/decimal/guards_test.exs
@@ -1,0 +1,11 @@
+if String.to_integer(System.otp_release()) > 22 and
+     Version.compare(System.version(), "1.11.0") != :lt do
+  defmodule DecimalGuardsTest do
+    use ExUnit.Case, async: true
+
+    require Decimal
+    import Decimal.Guards
+
+    doctest Decimal.Guards
+  end
+end


### PR DESCRIPTION
This pull request provides a set of guards to be used for Elixir ≥ 1.11 and OTP ≥ 23 versions.

```elixir
@doc "Call our internal imaginary `power/2` function conditionally"
def add(v, p) when is_decimal(v) and is_decimal_positive(p), do: power(v, p)
```

Example from tests:

```elixir
    iex> case {0, Decimal.cast("1"), "1"} do
    ...>   {i, {:ok, d}, s} when is_positive(d)
    ...>                         and not is_positive(i)
    ...>                         and not is_positive(s) -> :ok
    ...>   _ -> :error
    ...> end
    :ok
```

For earlier versions this is NOOP: the module is compiled under conditional statement.