### PR TITLE
Add zero and sum functions

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1160,6 +1160,18 @@ defmodule Decimal do
   end
 
   @doc """
+  Returns the default zero value of a Decimal.
+
+  ## Examples
+
+      iex> Decimal.zero()
+      Decimal.new(0)
+
+  """
+  @spec zero() :: t
+  def zero(), do: Decimal.new(0)
+
+  @doc """
   Creates a new decimal number from the sign, coefficient and exponent such that
   the number will be: `sign * coefficient * 10 ^ exponent`.
 

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1015,6 +1015,20 @@ defmodule Decimal do
   end
 
   @doc """
+  Returns the sum of all decimals in the enumerable.
+
+  ## Examples
+
+      iex> Decimal.sum([Decimal.new("1.234"), Decimal.new(2)])
+      Decimal.new("3.234")
+
+  """
+  @spec sum([decimal]) :: t
+  def sum(decimals) do
+    Enum.reduce(decimals, zero(), &add/2)
+  end
+
+  @doc """
   Finds the square root.
 
   ## Examples


### PR DESCRIPTION
Hello,

I have had to sum a list of decimals a few times and find it a bit tedious to always have to write the repetitive albeit simple reduce code.

Having to use `Decimal.new(0)`as the default value of the reducer also feels wrong somewhat.

This PR fixes both of these issues. It adds a `Decimal.zero/1` function which gives you the default zero value of the Decimal type, and a `Decimal.sum/1` function which takes an enumerable of Decimal and returns their sum.

I'm not an experienced Elixir developer, so this may not be the best way to do this in Elixir. I would have loved to find a way to implement `Enum.sum` for Decimal, but that would require overloading the `+` operator which does not seem like a good idea.

Thanks for your feedback!