### PR TITLE
Add scale/1

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1490,7 +1490,7 @@ defmodule Decimal do
       2
   """
   @spec scale(t) :: non_neg_integer()
-  def scale(%Decimal{exp: exp}), do: Enum.max([0, -exp])
+  def scale(%Decimal{exp: exp}), do: max(0, -exp)
 
   defp scale_up(num, den, exp) when num >= den, do: {num, exp}
   defp scale_up(num, den, exp), do: scale_up(num <<< 1, den, exp - 1)

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1480,6 +1480,9 @@ defmodule Decimal do
       iex> Decimal.scale(Decimal.new("42"))
       0
 
+      iex> Decimal.scale(Decimal.new(1, 2, 26))
+      0
+
       iex> Decimal.scale(Decimal.new("99.12345"))
       5
 
@@ -1487,7 +1490,7 @@ defmodule Decimal do
       2
   """
   @spec scale(t) :: non_neg_integer()
-  def scale(%Decimal{exp: exp}), do: -exp
+  def scale(%Decimal{exp: exp}), do: Enum.max([0, -exp])
 
   defp scale_up(num, den, exp) when num >= den, do: {num, exp}
   defp scale_up(num, den, exp), do: scale_up(num <<< 1, den, exp - 1)

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1490,7 +1490,7 @@ defmodule Decimal do
       2
   """
   @spec scale(t) :: non_neg_integer()
-  def scale(%Decimal{exp: exp}), do: max(0, -exp)
+  def scale(%Decimal{exp: exp}), do: Kernel.max(0, -exp)
 
   defp scale_up(num, den, exp) when num >= den, do: {num, exp}
   defp scale_up(num, den, exp), do: scale_up(num <<< 1, den, exp - 1)

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1469,6 +1469,26 @@ defmodule Decimal do
     end
   end
 
+  @doc """
+  Returns the scale of the decimal.
+
+  A decimal's scale is the number of digits after the decimal point. This
+  includes trailing zeros; see `normalize/1` to remove them.
+
+  ## Examples
+
+      iex> Decimal.scale(Decimal.new("42"))
+      0
+
+      iex> Decimal.scale(Decimal.new("99.12345"))
+      5
+
+      iex> Decimal.scale(Decimal.new("1.50"))
+      2
+  """
+  @spec scale(t) :: non_neg_integer()
+  def scale(%Decimal{exp: exp}), do: -exp
+
   defp scale_up(num, den, exp) when num >= den, do: {num, exp}
   defp scale_up(num, den, exp), do: scale_up(num <<< 1, den, exp - 1)
 


### PR DESCRIPTION
Based on https://github.com/ericmj/decimal/issues/190, what do you think of adding `scale/1`? I base this function name on the PostgreSQL documents:

> We use the following terms below: The precision of a numeric is the total count of significant digits in the whole number, that is, the number of digits to both sides of the decimal point. The scale of a numeric is the count of decimal digits in the fractional part, to the right of the decimal point. So the number 23.5141 has a precision of 6 and a scale of 4. Integers can be considered to have a scale of zero.
> https://www.postgresql.org/docs/current/datatype-numeric.html