### PR TITLE
Add gte?/2 and lte?/2

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -447,7 +447,7 @@ defmodule Decimal do
   def eq?(num1, num2), do: compare(num1, num2) == :eq
 
   @doc """
-  Compares two numbers numerically and returns `true` if the the first argument
+  Compares two numbers numerically and returns `true` if the first argument
   is greater than the second, otherwise `false`. If one the operands is a
   quiet NaN this operation will always return `false`.
 
@@ -467,7 +467,7 @@ defmodule Decimal do
   def gt?(num1, num2), do: compare(num1, num2) == :gt
 
   @doc """
-  Compares two numbers numerically and returns `true` if the the first number is
+  Compares two numbers numerically and returns `true` if the first number is
   less than the second number, otherwise `false`. If one of the operands is a
   quiet NaN this operation will always return `false`.
 
@@ -485,6 +485,74 @@ defmodule Decimal do
   def lt?(%Decimal{coef: :NaN}, _num2), do: false
   def lt?(_num1, %Decimal{coef: :NaN}), do: false
   def lt?(num1, num2), do: compare(num1, num2) == :lt
+
+  @doc """
+  Compares two numbers numerically and returns `true` if
+  the first argument is greater than or equal the second,
+  otherwise `false`.
+
+  If one the operands is a quiet NaN this operation
+  will always return `false`.
+
+  ## Examples
+
+      iex> Decimal.gte?("1.3", "1.3")
+      true
+
+      iex> Decimal.gte?("1.3", "1.2")
+      true
+
+      iex> Decimal.gte?("1.2", "1.3")
+      false
+
+  """
+  doc_since("2.2.0")
+  @spec gte?(decimal, decimal) :: boolean
+
+  def gte?(%Decimal{coef: :NaN}, _num2), do: false
+  def gte?(_num1, %Decimal{coef: :NaN}), do: false
+
+  def gte?(num1, num2) do
+    case compare(num1, num2) do
+      :gt -> true
+      :eq -> true
+      _ -> false
+    end
+  end
+
+  @doc """
+  Compares two numbers numerically and returns `true` if
+  the first number is less than or equal the second number,
+  otherwise `false`.
+
+  If one of the operands is a quiet NaN this operation
+  will always return `false`.
+
+  ## Examples
+
+      iex> Decimal.lte?("1.1", "1.1")
+      true
+
+      iex> Decimal.lte?("1.1", "1.2")
+      true
+
+      iex> Decimal.lte?("1.4", "1.2")
+      false
+
+  """
+  doc_since("2.2.0")
+  @spec lte?(decimal, decimal) :: boolean
+
+  def lte?(%Decimal{coef: :NaN}, _num2), do: false
+  def lte?(_num1, %Decimal{coef: :NaN}), do: false
+
+  def lte?(num1, num2) do
+    case compare(num1, num2) do
+      :lt -> true
+      :eq -> true
+      _ -> false
+    end
+  end
 
   @doc """
   Divides two numbers.

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -295,6 +295,24 @@ defmodule DecimalTest do
     refute Decimal.lt?(~d"1", ~d"nan")
   end
 
+  test "gte?/2" do
+    assert Decimal.gte?(~d"420", ~d"42e1")
+    assert Decimal.gte?(~d"1", ~d"0")
+    refute Decimal.gte?(~d"0", ~d"1")
+    assert Decimal.gte?(~d"0", ~d"-0")
+    refute Decimal.gte?(~d"nan", ~d"1")
+    refute Decimal.gte?(~d"1", ~d"nan")
+  end
+
+  test "lte?/2" do
+    assert Decimal.lte?(~d"420", ~d"42e1")
+    refute Decimal.lte?(~d"1", ~d"0")
+    assert Decimal.lte?(~d"0", ~d"1")
+    assert Decimal.lte?(~d"0", ~d"-0")
+    refute Decimal.lte?(~d"nan", ~d"1")
+    refute Decimal.lte?(~d"1", ~d"nan")
+  end
+
   test "div/2" do
     Context.with(%Context{precision: 5, rounding: :half_up}, fn ->
       assert Decimal.div(~d"1", ~d"3") == d(1, 33333, -5)


### PR DESCRIPTION
as asked in this issue: https://github.com/ericmj/decimal/issues/204
and I tried to keep it very similar to `gt?/2` and `lt?/2` both "doc-wise" and "test-wise".

I used a custom version of these functions a lot in another project so I thought it'd make sense to also add it here.

it's a common use case for "decimal libs" in other stacks. 😃 

![Screenshot 2024-04-01 at 22 54 04](https://github.com/ericmj/decimal/assets/6237270/d4f364fe-50ff-4556-958f-a00e3b88f174)

