### PR TITLE
Adds `compare/3` and `eq?/3` with threshold as parameter

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -309,7 +309,7 @@ defmodule Decimal do
   Compares two numbers numerically using a threshold. If the first number added
   to the threshold is greater than the second number, and the first number
   subtracted by the threshold is smaller than the second number, then the two
-  numbers are considered equal
+  numbers are considered equal.
 
   ## Examples
 
@@ -489,7 +489,7 @@ defmodule Decimal do
   @doc """
   It compares the equality of two numbers. If the second number is within
   the range of first - threshold and first + threshold, it returns true;
-  otherwise, it returns false
+  otherwise, it returns false.
 
   ## Examples
 

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -324,7 +324,10 @@ defmodule Decimal do
   """
   @spec compare(decimal :: decimal(), decimal :: decimal(), threshold :: decimal()) ::
           compare_result()
-  def compare(n1, n2, threshold) do
+
+  def compare(_, _, %Decimal{sign: -1}), do: raise(Error, reason: "threshold cannot be negative")
+
+  def compare(%Decimal{} = n1, %Decimal{} = n2, %Decimal{} = threshold) do
     add_threshold = n1 |> Decimal.add(threshold)
     sub_threshold = n1 |> Decimal.sub(threshold)
     case1 = compare(add_threshold, n2)
@@ -336,6 +339,8 @@ defmodule Decimal do
       case2 == :lt -> :lt
     end
   end
+
+  def compare(n1, n2, threshold), do: compare(decimal(n1), decimal(n2), decimal(threshold))
 
   @doc """
   Compares two numbers numerically. If the first number is greater than the second

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -306,9 +306,10 @@ defmodule Decimal do
   end
 
   @doc """
-  Compares two numbers numerically using a threshold. If first number added with threshold
-  is greater than second and the first subtracted with threshold is smaller than second than
-  it will be the same number
+  Compares two numbers numerically using a threshold. If the first number added
+  to the threshold is greater than the second number, and the first number
+  subtracted by the threshold is smaller than the second number, then the two
+  numbers are considered equal
 
   ## Examples
 
@@ -481,9 +482,9 @@ defmodule Decimal do
   def eq?(num1, num2), do: compare(num1, num2) == :eq
 
   @doc """
-  It compares equality of two numbers. If the second number
-  is equal of between `first - thresrold` and `first + thresrold`
-  then it returns `true`, otherwise it returns `false`.
+  It compares the equality of two numbers. If the second number is within
+  the range of first - threshold and first + threshold, it returns true;
+  otherwise, it returns false
 
   ## Examples
 

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -299,6 +299,7 @@ defmodule DecimalTest do
     assert Decimal.eq?(~d"420", ~d"42e1", ~d"0")
     assert Decimal.eq?(~d"1", ~d"0", ~d"1")
     refute Decimal.eq?(~d"1", ~d"0", ~d"0")
+
     assert_raise Error, fn ->
       Decimal.eq?(~d"nan", ~d"1", ~d"1")
     end

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -299,7 +299,9 @@ defmodule DecimalTest do
     assert Decimal.eq?(~d"420", ~d"42e1", ~d"0")
     assert Decimal.eq?(~d"1", ~d"0", ~d"1")
     refute Decimal.eq?(~d"1", ~d"0", ~d"0")
-    refute Decimal.eq?(~d"nan", ~d"1", ~d"1")
+    assert_raise Error, fn ->
+      Decimal.eq?(~d"nan", ~d"1", ~d"1")
+    end
   end
 
   test "gt?/2" do

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -259,6 +259,24 @@ defmodule DecimalTest do
     end
   end
 
+  test "compare/3" do
+    assert Decimal.compare(~d"420.5", ~d"42e1", "0.5") == :eq
+    assert Decimal.compare(~d"420.5", ~d"42e1", "0.2") == :gt
+
+    assert_raise Error, fn ->
+      Decimal.compare(~d"420.5", ~d"42e1", "-0.2")
+    end
+
+    assert Decimal.compare(~d"1", ~d"0", "0") == :gt
+
+    assert Decimal.compare(~d"-inf", ~d"inf", "100") == :lt
+    assert Decimal.compare(~d"inf", ~d"-inf", "0") == :gt
+    assert Decimal.compare(~d"0", ~d"inf", "1000000") == :lt
+
+    assert Decimal.compare(~d"0.123", ~d"0", "0") == :gt
+    assert Decimal.compare(~d"0.123", ~d"0", "0.2") == :eq
+  end
+
   test "equal?/2" do
     assert Decimal.equal?(~d"420", ~d"42e1")
     refute Decimal.equal?(~d"1", ~d"0")
@@ -275,6 +293,13 @@ defmodule DecimalTest do
     assert Decimal.eq?(~d"0", ~d"-0")
     refute Decimal.eq?(~d"nan", ~d"1")
     refute Decimal.eq?(~d"1", ~d"nan")
+  end
+
+  test "eq/3?" do
+    assert Decimal.eq?(~d"420", ~d"42e1", ~d"0")
+    assert Decimal.eq?(~d"1", ~d"0", ~d"1")
+    refute Decimal.eq?(~d"1", ~d"0", ~d"0")
+    refute Decimal.eq?(~d"nan", ~d"1", ~d"1")
   end
 
   test "gt?/2" do


### PR DESCRIPTION
It adds two new functions: `compare/3` and `eq?/3`. The new parameter is `threshold`. It compares the two numbers with a threshold. It's just to improve ergonomics. There're some situations that we don't want so much precision, mainly when we have periodic thites. It can be useful for testing situations.

```elixir
      iex> Decimal.compare("1.1", 1, "0.2")
      :eq

      iex> Decimal.compare("1.2", 1, "0.1")
      :gt

      iex> Decimal.compare("1.0", "1.2", "0.1")
      :lt

      iex> Decimal.eq?("1.0", 1, "0")
      true

      iex> Decimal.eq?("1.2", 1, "0.1")
      false

      iex> Decimal.eq?("1.2", 1, "0.2")
      true

      iex> Decimal.eq?(1, -1, "0.0")
      false
```