### PR TITLE
Fix typo in typespec

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -506,8 +506,8 @@ defmodule Decimal do
       false
 
   """
-  @spec eq?(decimal :: decimal(), decimal :: decimal(), thresrold :: decimal()) :: boolean()
-  def eq?(num1, num2, thresrold), do: compare(num1, num2, thresrold) == :eq
+  @spec eq?(decimal :: decimal(), decimal :: decimal(), threshold :: decimal()) :: boolean()
+  def eq?(num1, num2, threshold), do: compare(num1, num2, threshold) == :eq
 
   @doc """
   Compares two numbers numerically and returns `true` if the first argument

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -506,6 +506,7 @@ defmodule Decimal do
       false
 
   """
+  doc_since("2.2.0")
   @spec eq?(decimal :: decimal(), decimal :: decimal(), threshold :: decimal()) :: boolean()
   def eq?(num1, num2, threshold), do: compare(num1, num2, threshold) == :eq
 


### PR DESCRIPTION
Hello! While consulting the documentation, I noticed the following typo, which is now fixed in this PR. I'm also adding the "doc since" information to the `eq?/3` function, which was released on 2.2.0.