### PR TITLE
Add support for OTP 28 and Elixir 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MIX_ENV: test
     strategy:
@@ -16,14 +16,14 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.8.2
-              otp: 20.3.x
+              elixir: "1.12"
+              otp: "24"
           - pair:
-              elixir: 1.18.x
-              otp: 27.x
+              elixir: "1.18"
+              otp: "28"
             lint: lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: erlef/setup-beam@v1
         with:

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Decimal.Mixfile do
     [
       app: :decimal,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.12",
       deps: deps(),
       name: "Decimal",
       source_url: @source_url,
@@ -25,7 +25,7 @@ defmodule Decimal.Mixfile do
   defp deps() do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:stream_data, "~> 0.5.0", only: :test}
+      {:stream_data, "~> 1.2.0", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -5,5 +5,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "1.0.1", "e928a4f984e795e41e3abd27bfc09f51db16ab8ba1aebdba2b3a575437efafc2", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "7284900d412a3e5cfd97fdaed4f5ed389b8f2b4cb49efc0eb3bd10e2febf9507"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.1", "c7f58c120b2b5aa5fd80d540a89fdf866ed42f1f3994e4fe189abebeab610839", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "8a89a1eeccc2d798d6ea15496a6e4870b75e014d1af514b1b71fa33134f57814"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
-  "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
+  "stream_data": {:hex, :stream_data, "1.2.0", "58dd3f9e88afe27dc38bef26fce0c84a9e7a96772b2925c7b32cd2435697a52b", [:mix], [], "hexpm", "eb5c546ee3466920314643edf68943a5b14b32d1da9fe01698dc92b73f89a9ed"},
 }


### PR DESCRIPTION
This commit updates the CI workflow to introduce support for testing with
the latest versions of Erlang/OTP and Elixir.

List of changes:
- adding OTP 28 and Elixir 1.18 to the CI matrix
- bumping the actions/checkout action to version 5
- bumping the minimum Elixir version to 1.12 and the stream_data dependency to 1.2.0
- specifying the Elixir and OTP versions in the CI matrix as strings to avoid parsing issues
- support OTP/28 in CI
- updating the build runner to ubuntu-22.04