### PR TITLE
 Pass opts through to parse from Decimal.new/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Enhancements
+
+* `Decimal.new/2` now accepts an optional `opts` keyword list and
+  forwards it to `Decimal.parse/2`, allowing callers to override
+  `:max_digits` and `:max_exponent` when constructing a decimal from
+  a string.
+
 ### Bug fixes
 
 * Fix infinite loop in `Decimal.to_integer/1` when the coefficient is

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1453,6 +1453,8 @@ defmodule Decimal do
       iex> Decimal.new("2.22507385850720139e-308")
       Decimal.new("2.22507385850720139e-308")
 
+      iex> Decimal.new("1.01234567890123457890123457890123456789", max_digits: 39)
+      Decimal.new("1.01234567890123457890123457890123456789", max_digits: 39)
   """
   @spec new(decimal) :: t
   def new(%Decimal{sign: sign, coef: coef, exp: exp} = num)
@@ -1463,8 +1465,8 @@ defmodule Decimal do
   def new(int) when is_integer(int),
     do: %Decimal{sign: if(int < 0, do: -1, else: 1), coef: Kernel.abs(int)}
 
-  def new(binary) when is_binary(binary) do
-    case parse(binary) do
+  def new(binary, opts \\ []) when is_binary(binary) and is_list(opts) do
+    case parse(binary, opts) do
       {decimal, ""} -> decimal
       _ -> raise Error, reason: "number parsing syntax: #{inspect(binary)}"
     end

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -224,6 +224,27 @@ defmodule DecimalTest do
     end
   end
 
+  test "new/2 with opts" do
+    long = "1.01234567890123457890123457890123456789"
+
+    assert Decimal.new(long, max_digits: 39) ==
+             d(1, 101_234_567_890_123_457_890_123_457_890_123_456_789, -38)
+
+    assert_raise Error, fn ->
+      Decimal.new(long, max_digits: 38)
+    end
+
+    assert Decimal.new("1e10", max_exponent: 10) == d(1, 1, 10)
+
+    assert_raise Error, fn ->
+      Decimal.new("1e10", max_exponent: 9)
+    end
+
+    assert_raise ArgumentError, ~r/unknown option :unknown/, fn ->
+      Decimal.new("1", unknown: 1)
+    end
+  end
+
   test "from_float/1" do
     assert Decimal.from_float(123.0) == d(1, 1230, -1)
     assert Decimal.from_float(0.1) == d(1, 1, -1)


### PR DESCRIPTION
The 3.0 release introduced passing opts to Decimal.parse but Decimal.new/1 didn't expose it, so callers had no way to use those options when constructing a Decimal from a string via new.

This adds an optional opts argument to Decimal.new, forwarding it to parse/2.