### PR TITLE
Fix Elixir 1.20 compilation warnings

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -2799,8 +2799,6 @@ defmodule Decimal do
 
   defp fix_float_exp([], result), do: :lists.reverse(result)
 
-  defp check_dbl_min_max(%Decimal{coef: :inf} = infinity), do: infinity
-
   defp check_dbl_min_max(%Decimal{sign: 1} = num) do
     cond do
       Decimal.gt?(num, dbl_max(1)) ->


### PR DESCRIPTION
Resolve compilation warnings introduced in Elixir 1.20.

- Removed unreachable `check_dbl_min_max(%Decimal{coef: :inf})` clause. The only call site in `to_float/1` guards on `is_integer(coef)`, so the `:inf` pattern can never match.