### PR TITLE
Do not round exact values up under :up rounding

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -2463,7 +2463,11 @@ defmodule Decimal do
 
   defp increment?(:down, _, _, _, _), do: false
 
-  defp increment?(:up, _, _, _, _), do: true
+  # Round-up is away from zero, but per the General Decimal Arithmetic spec
+  # an all-zero discarded part leaves the value unchanged (an exact value is
+  # never rounded up). Check the discarded digits like :ceiling/:floor do,
+  # rather than incrementing unconditionally.
+  defp increment?(:up, _, _, remain, sticky?), do: any_nonzero?(remain, sticky?)
 
   defp increment?(:ceiling, sign, _, remain, sticky?),
     do: sign == 1 and any_nonzero?(remain, sticky?)

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -2465,8 +2465,7 @@ defmodule Decimal do
 
   # Round-up is away from zero, but per the General Decimal Arithmetic spec
   # an all-zero discarded part leaves the value unchanged (an exact value is
-  # never rounded up). Check the discarded digits like :ceiling/:floor do,
-  # rather than incrementing unconditionally.
+  # never rounded up). Check the discarded digits like :ceiling/:floor do.
   defp increment?(:up, _, _, remain, sticky?), do: any_nonzero?(remain, sticky?)
 
   defp increment?(:ceiling, sign, _, remain, sticky?),

--- a/test/decimal/context_test.exs
+++ b/test/decimal/context_test.exs
@@ -82,6 +82,17 @@ defmodule Decimal.ContextTest do
       assert Decimal.add(~d"0", ~d"-102") == d(-1, 11, 1)
       assert Decimal.add(~d"0", ~d"1.1") == d(1, 11, -1)
     end)
+
+    # :up rounds away from zero only when a discarded digit is nonzero. An
+    # exact value whose dropped digits are all zero must be left unchanged
+    # (matches the General Decimal Arithmetic spec and Python's decimal).
+    Context.with(%Context{precision: 1, rounding: :up}, fn ->
+      assert Decimal.add(~d"0", ~d"9.0") == d(1, 9, 0)
+      assert Decimal.add(~d"0", ~d"-9.0") == d(-1, 9, 0)
+      assert Decimal.mult(~d"9.00", ~d"1") == d(1, 9, 0)
+      # a nonzero discarded digit still rounds up
+      assert Decimal.add(~d"0", ~d"3.1") == d(1, 4, 0)
+    end)
   end
 
   test "with_context/2: large exponent gap addition" do


### PR DESCRIPTION
Follows up on the `:up` bug I noted in #236 — independent of #237 and #238.

## Problem

`:up` (round away from zero) increments the coefficient whenever the discarded part is non-empty, even when all discarded digits are zero. An exact value with trailing zeros beyond the precision is rounded up:

```elixir
Context.with(%Context{precision: 1, rounding: :up}, fn ->
  Decimal.add(Decimal.new(0), Decimal.new("9.0"))   #=> Decimal.new("10")   # value is exactly 9
end)

Decimal.round(Decimal.new("9.0"), 0, :up)           #=> Decimal.new("10")   # should be 9
```

Per the General Decimal Arithmetic spec, round-up leaves the value unchanged when every discarded digit is zero. Python's `decimal` returns `9` for both. `:ceiling` and `:floor` already guard on `any_nonzero?/2` — so today, for a positive value, `:up` and `:ceiling` disagree even though both round away from zero (`Decimal.add(0, ~d"9.0")` at precision 1 gives `10` under `:up` but `9` under `:ceiling`). They must agree.

## Fix

`increment?(:up, …)` now checks `any_nonzero?(remain, sticky?)` instead of returning `true` unconditionally — the same check `:ceiling`/`:floor` use. One clause.

## Verification

Differential fuzz against Python's `decimal` (the GDA reference), comparing numeric values: **0 mismatches across ~3,800 `:up` cases** spanning `add`/`sub`/`mult`/`div` and `round/3`, at precisions 1–5. Genuine round-ups still round up (`add(0, 3.1)` at precision 1 → `4`; `round(9.01, 0, :up)` → `10`).

## Tests

Extends the existing `with_context/2: up` test with the exact-value cases (and a nonzero-discarded case that still rounds up). Full suite passes (`101 doctests, 27 properties, 101 tests`).

## Notes

- Independent of #237 and #238: different clause, and the three branches merge cleanly (code) in any order.
- I've intentionally left the CHANGELOG entry out of this PR to avoid a conflict with the `## Unreleased` sections added by #237 and #238 — happy to add one (or fold all three into a single entry) once you've decided merge order.
