### PR TITLE
Require Elixir 1.15 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: "1.12"
-              otp: "24"
+              elixir: "1.15"
+              otp: "26"
           - pair:
               elixir: "1.19"
               otp: "28"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+* Require Elixir 1.15 or later.
+
 ### Enhancements
 
 * Reduce the cost of every operation that goes through the context: results

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Decimal.Mixfile do
     [
       app: :decimal,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.15",
       deps: deps(),
       name: "Decimal",
       source_url: @source_url,


### PR DESCRIPTION
## Summary

- raise Decimal's minimum supported Elixir version from 1.12 to 1.15
- move the lower CI pair from Elixir 1.12 / OTP 24 to Elixir 1.15 / OTP 26
- record the compatibility change under the unreleased changelog

## Why this matters

ExDoc v0.40 requires Elixir 1.15 and adds native Markdown documentation and `llms.txt` generation. Raising the runtime floor separately keeps that compatibility decision explicit instead of hiding it inside a documentation-tool update.

This also moves the project's tested baseline onto a substantially newer compiler and OTP generation while retaining the existing current-runtime CI pair.

## Compatibility

This intentionally drops support for Elixir 1.12 through 1.14. It does not change Decimal's source or public API. The lower CI job now verifies the proposed minimum directly.

## Verification

- `mix format --check-formatted mix.exs`
- `MIX_ENV=test mix deps.unlock --check-unused`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix test` — 266 passed (105 doctests, 36 properties, 125 tests)
