### PR TITLE
Resolve Elixir 1.20 type checker warnings

### DIFF
--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -277,7 +277,7 @@ defmodule Decimal do
     defmacro is_decimal(term) do
       case __CALLER__.context do
         nil ->
-          quote do
+          quote generated: true do
             case unquote(term) do
               %Decimal{} -> true
               _ -> false
@@ -299,7 +299,7 @@ defmodule Decimal do
   else
     # TODO: remove when we require Elixir v1.10
     defmacro is_decimal(term) do
-      quote do
+      quote generated: true do
         case unquote(term) do
           %Decimal{} -> true
           _ -> false

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -213,8 +213,10 @@ defmodule DecimalTest do
     assert Decimal.new(d(-1, 3, 2)) == d(-1, 3, 2)
     assert Decimal.new(123) == d(1, 123, 0)
 
+    # apply/3 keeps the intentionally invalid argument opaque to the
+    # type checker; the raise is the point.
     assert_raise FunctionClauseError, fn ->
-      Decimal.new(:atom)
+      apply(Decimal, :new, [:atom])
     end
   end
 
@@ -943,8 +945,10 @@ defmodule DecimalTest do
         fn -> Decimal.to_integer(d(1, 1001, -2)) end
       )
 
+      # apply/3 keeps the intentionally invalid argument opaque to the
+      # type checker; the raise is the point.
       assert_raise FunctionClauseError, fn ->
-        Decimal.to_integer(d(1, :NaN, 0))
+        apply(Decimal, :to_integer, [d(1, :NaN, 0)])
       end
     end)
   end
@@ -1401,8 +1405,10 @@ defmodule DecimalTest do
   end
 
   test "issue #60" do
+    # apply/3 keeps the intentionally invalid argument opaque to the
+    # type checker; the raise is the point.
     assert_raise(FunctionClauseError, "no function clause matching in Decimal.decimal/1", fn ->
-      Decimal.round(nil)
+      apply(Decimal, :round, [nil])
     end)
   end
 


### PR DESCRIPTION
Two sources, no behavior change:

The non guard expansions of `is_decimal/1` are a case with a %Decimal{}
clause and a catch all. When the argument is statically known to be a
%Decimal{} the type checker proves the catch all unreachable and warns
at every such call site, including the doctest. Marking the quoted
expansion `generated: true` declares the catch all deliberate,
following the convention for macro generated code.

Three tests pass intentionally invalid input to assert the raise
(new/1 with an atom, to_integer/1 with a NaN coefficient, round/1 with
nil). Routing those calls through apply/3 keeps the argument opaque to
the type checker, which does not check dynamic dispatch, while
exercising exactly the same failure path.