### PR TITLE
Apply only the caller's rounding mode in round/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,22 +37,17 @@
   operation (`add`, `sub`, `mult`, `div`) and now matches the General
   Decimal Arithmetic spec and Python's decimal.
 
-* Fix `Decimal.round/3` applying the context's rounding mode before the
-  caller's. The value was routed through the full context first, which
-  rounded the coefficient to `precision` under `Context.get().rounding`, so
-  an input with more significant digits than the precision was rounded twice
-  and the first rounding ignored the `mode` argument. At `precision: 3`,
-  `Decimal.round(Decimal.new("0.4995"), 1, :down)` returned `0.5` — above the
-  value it was asked to truncate. Coefficients wider than the precision reach
-  `round/3` at the default context whenever they are not built through
-  `new/1`, which rejects them at its parse limit: `new/3` performs no digit
-  count, and database drivers decoding a numeric column build the struct the
-  same way. Only the exponent limits are now applied to the input, so `mode`
-  is the only rounding applied before the result reaches the context. As a
-  result `round/3` no longer signals `:inexact`/`:rounded` merely because its
-  *input* was wider than the precision. It still signals when the *result*
-  reaches the context wider than the precision, as every operation does, and
-  it still does not signal for the digits it discards itself.
+* Fix `Decimal.round/3` rounding the input under the context's rounding mode
+  before the caller's. The input went through the full context first, so a
+  coefficient with more significant digits than the precision was rounded
+  twice and the first rounding ignored the `mode` argument: at
+  `precision: 3`, `Decimal.round(Decimal.new("0.4995"), 1, :down)` returned
+  `0.5`. Such inputs come from `new/3`, which performs no digit count. Only
+  the exponent limits are now applied to the input. `round/3` no longer
+  signals `:inexact`/`:rounded` because its input was wider than the
+  precision; it still signals when the result reaches the context wider than
+  the precision, as every operation does, and still does not signal for the
+  digits it discards itself.
 
 ## v3.1.1 (2026-05-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,23 @@
   operation (`add`, `sub`, `mult`, `div`) and now matches the General
   Decimal Arithmetic spec and Python's decimal.
 
+* Fix `Decimal.round/3` applying the context's rounding mode before the
+  caller's. The value was routed through the full context first, which
+  rounded the coefficient to `precision` under `Context.get().rounding`, so
+  an input with more significant digits than the precision was rounded twice
+  and the first rounding ignored the `mode` argument. At `precision: 3`,
+  `Decimal.round(Decimal.new("0.4995"), 1, :down)` returned `0.5` — above the
+  value it was asked to truncate. Coefficients wider than the precision reach
+  `round/3` at the default context whenever they are not built through
+  `new/1`, which rejects them at its parse limit: `new/3` performs no digit
+  count, and database drivers decoding a numeric column build the struct the
+  same way. Only the exponent limits are now applied to the input, so `mode`
+  is the only rounding `round/3` performs. As a result `round/3` no longer
+  sets `:inexact`/`:rounded` for an over-precision input; it did not set them
+  for the digits it discards itself, so it now signals for neither, remaining
+  a round-to-integral-value style operation that does not signal for the
+  digits it discards.
+
 ## v3.1.1 (2026-05-27)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,11 @@
   `new/1`, which rejects them at its parse limit: `new/3` performs no digit
   count, and database drivers decoding a numeric column build the struct the
   same way. Only the exponent limits are now applied to the input, so `mode`
-  is the only rounding `round/3` performs. As a result `round/3` no longer
-  sets `:inexact`/`:rounded` for an over-precision input; it did not set them
-  for the digits it discards itself, so it now signals for neither, remaining
-  a round-to-integral-value style operation that does not signal for the
-  digits it discards.
+  is the only rounding applied before the result reaches the context. As a
+  result `round/3` no longer signals `:inexact`/`:rounded` merely because its
+  *input* was wider than the precision. It still signals when the *result*
+  reaches the context wider than the precision, as every operation does, and
+  it still does not signal for the digits it discards itself.
 
 ## v3.1.1 (2026-05-27)
 

--- a/lib/decimal.ex
+++ b/lib/decimal.ex
@@ -1369,13 +1369,16 @@ defmodule Decimal do
   def round(%Decimal{coef: :inf} = num, _, _), do: num
 
   def round(%Decimal{} = num, n, mode) do
-    case normalize(num) do
+    ctx = Context.get()
+
+    case exponent_limited(num, ctx) do
       %Decimal{coef: :inf} = num ->
         num
 
       %Decimal{sign: sign, coef: coef, exp: exp} ->
+        {coef, exp} = strip_trailing_zeros(coef, exp)
         value = do_round(sign, coef, exp, -n, mode)
-        context(value, [])
+        context(value, [], false, ctx)
     end
   end
 
@@ -2700,6 +2703,17 @@ defmodule Decimal do
 
   defp merge_signals(signals, prec_signals, exp_signals) do
     signals |> put_uniq(prec_signals) |> put_uniq(exp_signals)
+  end
+
+  # The exponent half of `context/5` without the precision half, for `round/3`.
+  # The limits still have to be applied to the input: an adjusted exponent past
+  # `emax` must overflow before `do_round/5` scales the coefficient by
+  # `pow10(exp - target_exp)`, which is otherwise unbounded for an exponent
+  # built through `new/3`. The precision half must not run, because the
+  # caller's `mode` is the only rounding `round/3` was asked to perform.
+  defp exponent_limited(%Decimal{coef: coef} = num, %Context{} = context) do
+    {result, signals} = exponent_limits(num, coef_length(coef), context)
+    error(signals, nil, result, context)
   end
 
   defp exponent_limits(%Decimal{coef: coef} = num, _digits, _context)

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -1152,35 +1152,25 @@ defmodule DecimalTest do
   end
 
   test "round/3 applies only the caller's rounding mode" do
-    # The input used to be routed through the full context, which rounded the
-    # coefficient to `precision` under `ctx.rounding` before `mode` was ever
-    # applied. An input wider than the precision was then rounded twice, and
-    # the first rounding ignored `mode`: :half_up carried 0.4995 to 0.500 and
-    # :down truncated that to 0.5 - above the value it was asked to truncate.
+    # Inputs wider than the precision, under a context mode that disagrees
+    # with `mode`.
     Context.with(%Context{precision: 3}, fn ->
       assert Decimal.round(~d"0.4995", 1, :down) == d(1, 4, -1)
     end)
 
-    # The context's mode must not leak in either direction. Rounding up first
-    # under :ceiling turned a truncation into an increment...
     Context.with(%Context{precision: 3, rounding: :ceiling}, fn ->
       assert Decimal.round(~d"0.4991", 1, :down) == d(1, 4, -1)
     end)
 
-    # ...and truncating first under :floor discarded the nonzero digits that
-    # :ceiling needs to see, leaving it short of the true ceiling.
     Context.with(%Context{precision: 3, rounding: :floor}, fn ->
       assert Decimal.round(~d"0.4001", 1, :ceiling) == d(1, 5, -1)
     end)
   end
 
   test "round/3 does not double-round coefficients wider than the precision" do
-    # Such values cannot be built through `new/1` at the default context - the
-    # parse limit and the precision are both 34, so the literal is rejected -
-    # but `new/3` performs no digit count, and a driver decoding a numeric
-    # column builds the struct the same way. 0.4999...95 has 35 significant
-    # digits: truncating gives 0.4, while rounding to 34 digits first carries
-    # it to exactly 0.5.
+    # 35 significant digits, one more than the default precision (`new/3`
+    # performs no digit count). Rounded to 34 digits first it would carry to
+    # exactly 0.5.
     coef = String.to_integer("4" <> String.duplicate("9", 33) <> "5")
     num = Decimal.new(1, coef, -35)
 

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -1151,6 +1151,56 @@ defmodule DecimalTest do
     assert roundneg.(~d"1099") == d(1, 11, 2)
   end
 
+  test "round/3 applies only the caller's rounding mode" do
+    # The input used to be routed through the full context, which rounded the
+    # coefficient to `precision` under `ctx.rounding` before `mode` was ever
+    # applied. An input wider than the precision was then rounded twice, and
+    # the first rounding ignored `mode`: :half_up carried 0.4995 to 0.500 and
+    # :down truncated that to 0.5 - above the value it was asked to truncate.
+    Context.with(%Context{precision: 3}, fn ->
+      assert Decimal.round(~d"0.4995", 1, :down) == d(1, 4, -1)
+    end)
+
+    # The context's mode must not leak in either direction. Rounding up first
+    # under :ceiling turned a truncation into an increment...
+    Context.with(%Context{precision: 3, rounding: :ceiling}, fn ->
+      assert Decimal.round(~d"0.4991", 1, :down) == d(1, 4, -1)
+    end)
+
+    # ...and truncating first under :floor discarded the nonzero digits that
+    # :ceiling needs to see, leaving it short of the true ceiling.
+    Context.with(%Context{precision: 3, rounding: :floor}, fn ->
+      assert Decimal.round(~d"0.4001", 1, :ceiling) == d(1, 5, -1)
+    end)
+  end
+
+  test "round/3 does not double-round coefficients wider than the precision" do
+    # Such values cannot be built through `new/1` at the default context - the
+    # parse limit and the precision are both 34, so the literal is rejected -
+    # but `new/3` performs no digit count, and a driver decoding a numeric
+    # column builds the struct the same way. 0.4999...95 has 35 significant
+    # digits: truncating gives 0.4, while rounding to 34 digits first carries
+    # it to exactly 0.5.
+    coef = String.to_integer("4" <> String.duplicate("9", 33) <> "5")
+    num = Decimal.new(1, coef, -35)
+
+    assert Decimal.round(num, 1, :down) == d(1, 4, -1)
+    assert Decimal.round(num, 1, :floor) == d(1, 4, -1)
+    assert Decimal.round(num, 1, :half_even) == d(1, 5, -1)
+  end
+
+  @tag timeout: @bounded_smoke_timeout
+  test "round/3 applies the exponent limits before scaling the coefficient" do
+    # The limits have to be checked on the input: without them `do_round/5`
+    # would build `coef * pow10(exp - target_exp)` - ten million digits here -
+    # only for the context to discard it.
+    num = %Decimal{sign: 1, coef: 1, exp: 10_000_000}
+
+    assert_runs_quickly("round/3 bounded huge exponent", fn ->
+      assert Decimal.round(num, 0) == d(1, :inf, 0)
+    end)
+  end
+
   test "sqrt/1" do
     Context.with(%Context{precision: 9, rounding: :half_even}, fn ->
       assert Decimal.sqrt(~d"0") == d(1, 0, 0)

--- a/test/decimal_test.exs
+++ b/test/decimal_test.exs
@@ -1201,6 +1201,26 @@ defmodule DecimalTest do
     end)
   end
 
+  test "round/3 signals only for what the context rounds" do
+    # The digits `round/3` itself discards never signal: dropping "34" here
+    # sets no flag.
+    Context.with(%Context{precision: 3}, fn ->
+      assert Decimal.round(~d"1.234", 1) == d(1, 12, -1)
+      assert Context.get().flags == []
+    end)
+
+    # The result still goes through the context like any other operation, so a
+    # coefficient `places` does not narrow below the precision is rounded there
+    # - under `ctx.rounding` rather than the mode passed here - and signals.
+    Context.with(%Context{precision: 3}, fn ->
+      assert Decimal.round(~d"0.4995", 4, :down) == d(1, 500, -3)
+
+      flags = Context.get().flags
+      assert :inexact in flags
+      assert :rounded in flags
+    end)
+  end
+
   test "sqrt/1" do
     Context.with(%Context{precision: 9, rounding: :half_even}, fn ->
       assert Decimal.sqrt(~d"0") == d(1, 0, 0)


### PR DESCRIPTION
Fixes #247 . Implements the minimal fix agreed there: round to `places` under
`mode`, with only the result going through the context; no new signalling; and
the exponent limits kept on the input.

## The bug

`round/3` rounded twice for any value whose coefficient carried more
significant digits than the context precision. The first rounding used
`Context.get().rounding`, not the `mode` argument, so the result could violate
the defining property of the mode the caller asked for.

```elixir
Decimal.Context.set(%Decimal.Context{precision: 3})

Decimal.round(Decimal.new("0.4995"), 1, :down)
#=> Decimal.new("0.5")
```

The context's `:half_up` carried `0.4995` to `0.500`; `:down` then truncated
that. Truncating the input gives `0.4`.

The context's mode intrudes in both directions, truncating first under
`:floor` discards the nonzero digits `:ceiling` needs to see:

```elixir
Decimal.Context.set(%Decimal.Context{precision: 3, rounding: :floor})

Decimal.round(Decimal.new("0.4001"), 1, :ceiling)
#=> Decimal.new("0.4")
```

## Cause

`round/3` normalized its input, and `normalize/1` applies the context on both
of its non-zero branches. `context/5` rounds the coefficient to `ctx.precision`
under `ctx.rounding`, so `do_round/5` received a value already rounded under a
mode the caller never asked for.

## Reachability

At the default context the parse limit (`max_digits: 34`) and the precision
(34) coincide, so an over-precision literal never survives `Decimal.new/1`
it is rejected as a parse error. That check guards only the parsing path though,
and `new/3` performs no digit count.

`new/3` is the path a database driver takes. `Postgrex.Extensions.Numeric`
decodes a `numeric` by accumulating base-10000 digit groups from the binary
wire format and calling `Decimal.new(sign, coef, -scale)`, so nothing consults
`max_digits`. A Postgres `numeric` with no type modifier is unconstrained, so a
column value or an `AVG(numeric)` result can carry far more than 34
significant digits straight into `round/3` at the default context:

```elixir
coef = String.to_integer("4" <> String.duplicate("9", 33) <> "5")

Decimal.round(Decimal.new(1, coef, -35), 1, :down)
#=> Decimal.new("0.5") at the default precision; 0.4 after this change
```

That is the construction Postgrex produces, and the regression test uses it.

## The fix

**Drop the precision pass on the input.** This is the bug itself: the rounding
that used `ctx.rounding` in place of `mode`.

**Keep the exponent limits on the input**, via a new `exponent_limited/2` — the
exponent half of `context/5` without the precision half. `do_round/5` scales
the coefficient by `pow10(exp - target_exp)` when `exp > target_exp`, which is
unbounded for an exponent built through `new/3`; without the check,
`Decimal.round(Decimal.new(1, 1, 10_000_000), 0)` would build a
ten-million-digit coefficient only for the context to discard it. Checking
before the zero-strip rather than after is safe: stripping moves `exp` and the
digit count in opposite directions by the same amount, so the adjusted exponent
is identical either way.

Because that check can itself overflow to Infinity, `round/3` keeps a
`%Decimal{coef: :inf}` case arm. It catches an overflow produced there, not an
Infinity passed in, the function clause above already handles that.

**Strip trailing zeros directly** with `strip_trailing_zeros/2`, which is what
`normalize/1` contributed besides the context call. This one is an optimization
rather than a correctness requirement. `split_digits/3` handles trailing zeros
identically with or without it, but it keeps `do_round/5` off needlessly wide
coefficients.

Those three are also sufficient: nothing else between the input and
`do_round/5` rounds, so `mode` is the only rounding `round/3` now applies. The
final `context/4` call on the *result* is unchanged and still bounds it to the
precision. That is the same contract every other operation has, and it acts on
the rounded result rather than on the digits `mode` was deciding about.

## Behavior changes

* Inputs wider than the precision round once, under the caller's mode.

* `round/3` no longer sets `:inexact`/`:rounded` for an over-precision input.
  It never signalled for the digits it discards itself, so it now signals for
  neither rather than only in that incidental case, keeping it a
  round-to-integral-value style operation that does not signal for discarded
  digits.

## Not a regression

Long-standing, not introduced by #240 or #241. At `eb75d13`, the base commit
for both, `round/3` already called `normalize/1` and `normalize/1` already
ended in `|> context`.

## Tests

* Mode isolation across `:down`, `:ceiling` and `:floor` contexts
* The 35-digit `new/3` case at the default precision
* A bounded-time check that a `10^7` exponent still overflows without
  materializing the coefficient

Existing `round/3` tests pass unchanged: they use small values at the default
precision, where the removed pass was already a no-op.